### PR TITLE
Fixed VarDecl warnings

### DIFF
--- a/CocoR/voresGrammer.atg
+++ b/CocoR/voresGrammer.atg
@@ -46,8 +46,7 @@ PRODUCTIONS
   .
 
   VarDecl =
-      Type ident
-    | Type ident ":=" Expr
+    Type ident [ ":=" Expr ]
   .
 
   Type =

--- a/CocoR/voresGrammer.atg
+++ b/CocoR/voresGrammer.atg
@@ -66,13 +66,13 @@ PRODUCTIONS
   .
 
   ResourceDecl =
-    ident ident "{"
+    ident ident ["{"
       { VarDecl ";" }
-    "}"
+    "}"]
   .
 
   CategoryDecl =
-    "category" ident [ "is" "a" ident ]
+    "category" ident [ "is a" ident ]
   .
 
   TemplateDecl =


### PR DESCRIPTION
These are the VarDecl warnings that have now been fixed.

 LL1 warning in VarDecl: "Resource" is start of several alternatives
  LL1 warning in VarDecl: "Reservation" is start of several alternatives
  LL1 warning in VarDecl: "TimePeriod" is start of several alternatives
  LL1 warning in VarDecl: "DateTime" is start of several alternatives
  LL1 warning in VarDecl: "Duration" is start of several alternatives
  LL1 warning in VarDecl: "int" is start of several alternatives
  LL1 warning in VarDecl: "bool" is start of several alternatives
  LL1 warning in VarDecl: "string" is start of several alternatives
  LL1 warning in VarDecl: "float" is start of several alternatives