### PR TITLE
Declarations & initialization

### DIFF
--- a/CocoR/voresGrammer.atg
+++ b/CocoR/voresGrammer.atg
@@ -46,8 +46,7 @@ PRODUCTIONS
   .
 
   VarDecl =
-      Type ident
-    | Type ident ":=" Expr
+    Type ident [ ":=" Expr ]
   .
 
   Type =

--- a/CocoR/voresGrammer.atg
+++ b/CocoR/voresGrammer.atg
@@ -66,13 +66,13 @@ PRODUCTIONS
   .
 
   ResourceDecl =
-    ident ident "{"
+    ident ident ["{"
       { VarDecl ";" }
-    "}"
+    "}"]
   .
 
   CategoryDecl =
-    "category" ident [ "is" "a" ident ]
+    "category" ident [ "is a" ident ]
   .
 
   TemplateDecl =


### PR DESCRIPTION
This pull request makes several improvements to the grammar definitions in `voresGrammer.atg`, focusing on simplifying and making the syntax more flexible for variable and resource declarations, as well as clarifying category declarations.

**Grammar simplification and flexibility:**

* Updated `VarDecl` to allow variable declarations with or without initialization by making the `":=" Expr` part optional.
* Modified `ResourceDecl` so that the block of variable declarations is now optional, allowing resources to be declared without any variables.

**Clarity improvements:**

* Changed the `CategoryDecl` to treat `"is a"` as a single optional phrase, which simplifies parsing and improves readability.