### PR TITLE
further type checking

### DIFF
--- a/CocoR/ralGrammar.cs.atg
+++ b/CocoR/ralGrammar.cs.atg
@@ -170,7 +170,7 @@ PRODUCTIONS
     "move"     (. int lineNumber = t.line; .)
     ident      (. string resourceId = t.val; .)
     "to"   
-    ident      (. string categoryId = t.val; stmt = new Move(lineNumber, resourceId, categoryId); .)
+    ident      (. stmt = new Move(lineNumber, resourceId, new ResourceT(t.val)); .)
   .
 
   Cancel<out Stmt stmt> =
@@ -198,7 +198,7 @@ PRODUCTIONS
 
 // Resource, Ident
   ResourceDecl<out Stmt stmt> =  
-    ResourceType <out TypeT type> (. int lineNumber = t.line; .)
+    ident                         (. int lineNumber = t.line; ResourceT type = new ResourceT(t.val); .) //* Resource of a user-defined category */
     ident                         (. string identifier = t.val; List<Stmt>? propertyList = null; .)
       
     "{" /* Force {}. Property set cannot change later, user aware.*/
@@ -217,14 +217,8 @@ PRODUCTIONS
   ParamType<out TypeT type> (. type = null; .) 
   =
     Type<out type>
-    | ResourceType<out type>
+    | ident                 (. type = new ResourceT(t.val); .) //* Resource of a user-defined category */
  .
-
-  // Used in resource declaration & declaring formal parameters of a template
-  ResourceType<out TypeT type> (. type = null; .)
-  = 
-    ident         (. type = new ResourceT(t.val); .) //* Resource of a user-defined category */
-  .
 
   // Used in variable declaration & formal parameters of a template
   Type <out TypeT type> (. type = null; .)
@@ -455,25 +449,28 @@ PRODUCTIONS
     .
 
   /*alternative that does not enforce unit structure/repetition = number Unit {number Unit} */
-  /* number, not expression. Would give lookahead problem otherwise */
-  Duration<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
+  /* number, not expression. Would give lookahead problem otherwise 
+  DurationRefactored<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
+    
       (
-      IF(FollowedByWeek())
-      number (. days = int.Parse(t.val) * 7; .)
-      ("w" | "week" | "weeks")
-      [ number (. days += int.Parse(t.val); .) 
-      ("d" | "day" | "days") ]
-      [ number (. hours = int.Parse(t.val); .) 
-      ("h" | "hour" | "hours") ]
-      [ number (. minutes = int.Parse(t.val); .) 
-      ("m" | "minute" | "minutes") ]
+      IF(FollowedByWeek()) number (. days = int.Parse(t.val) * 7; .) ("w" | "week" | "weeks")
+      [ 
+        number (. days += int.Parse(t.val); .) ("d" | "day" | "days") 
+      ]
+      [ 
+        number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
+      ]
+      [ 
+        number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes") 
+      ]
 
     | IF(FollowedByDay())
-      number (. days = int.Parse(t.val); .)
-      ("d" | "day" | "days")
-      [ number (. hours = int.Parse(t.val); .) 
-      ("h" | "hour" | "hours") ]
-      [ number (. minutes = int.Parse(t.val); .) 
+      number (. days = int.Parse(t.val); .) ("d" | "day" | "days")
+      [ 
+        number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
+      ]
+      [ 
+        number (. minutes = int.Parse(t.val); .) 
       ("m" | "minute" | "minutes") ]
 
     | IF(FollowedByHour())
@@ -487,7 +484,65 @@ PRODUCTIONS
     )
 
     (. exp = new DurationV(t.line, new TimeSpan(days, hours, minutes, 0)); .)
+  .*/
+
+/** to use
+  Duration<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
+    
+    Weeks | Days | Hours | Minutes 
+      
+      (. exp = new DurationV(t.line, new TimeSpan(days, hours, minutes, 0)); .)
+    .
+
+  Weeks<out int days> =
+    IF(FollowedByWeek()) number (. days = int.Parse(t.val) * 7; .) ("w" | "week" | "weeks") [Days]
   .
+
+  Days<out int days> = 
+    IF(FollowedByDay()) number (. days = int.Parse(t.val); .) ("d" | "day" | "days") [Hours]
+  .
+
+  Hours<out int hours> = 
+    IF(FollowedByHour())  number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") [Minutes]
+  .
+
+  Minutes<out int minutes> =
+     number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes")
+  .
+*/
+  Duration<out Exp exp> (. exp = null; int weeks = 0, days = 0, hours = 0, minutes = 0; .)
+    =
+    ((
+      IF(FollowedByWeek())
+      number                        (. weeks = int.Parse(t.val); .)
+      ("w" | "week" | "weeks")
+
+    | IF(FollowedByDay())
+      number                        (. days = int.Parse(t.val); .)
+      ("d" | "day" | "days")
+
+    | IF(FollowedByHour())
+      number                        (. hours = int.Parse(t.val); .)
+      ("h" | "hour" | "hours")
+
+    | number                        (. minutes = int.Parse(t.val); .)
+      ("m" | "minute" | "minutes")
+    )
+
+    [ IF(FollowedByDay())
+      number                        (. days = int.Parse(t.val); .)
+      ("d" | "day" | "days") ]
+
+    [ IF(FollowedByHour())
+      number                        (. hours = int.Parse(t.val); .)
+      ("h" | "hour" | "hours") ]
+
+    [ 
+      number                        (. minutes = int.Parse(t.val); .)
+      ("m" | "minute" | "minutes") ]
+    )
+    (. exp = new DurationV(t.line, new TimeSpan(days + weeks * 7, hours, minutes, 0)); .)
+    .
 
                    
   Recurrence<out RecurrenceSpec recurrence> = //assigning default to bypass unassigned local variable error in parser  

--- a/src/RAL/AST/Stmt.cs
+++ b/src/RAL/AST/Stmt.cs
@@ -14,13 +14,13 @@ record class Composite(int LineNumber, Stmt? Stmt1, Stmt? Stmt2 ) : Stmt(LineNum
 
 record class VarDecl(int LineNumber, TypeT Type, string Identifier) : Stmt(LineNumber);
 //Null -> no properties. Non-null -> at least one property. List<Stmt> -> each element may be Vardecl | Comp(Vardecl, Assignment)
-record class ResourceDecl(int LineNumber, TypeT Type, string Identifier, List<Stmt>? PropertyList) : Stmt(LineNumber);
+record class ResourceDecl(int LineNumber, ResourceT Type, string Identifier, List<Stmt>? PropertyList) : Stmt(LineNumber);
 
 record class CategoryDecl (int LineNumber, string CategoryId, string? ParentId) : Stmt(LineNumber);
 
 record class TemplateDecl(int LineNumber, string TemplateId, List<VarDecl>? ParamList, Stmt? TemplateBody) : Stmt(LineNumber);
 
-record class Move(int LineNumber, string ResourceId, string CategoryId ) : Stmt(LineNumber);
+record class Move(int LineNumber, string ResourceId, ResourceT Type ) : Stmt(LineNumber);
 
 /*                                 might be id, might be a reserve expression */
 record class Cancel(int LineNumber, Exp Reservation) : Stmt(LineNumber);

--- a/src/RAL/AST/Type.cs
+++ b/src/RAL/AST/Type.cs
@@ -18,4 +18,6 @@ public sealed record DurationT : TypeT { public override string ToString() { ret
 
 public sealed record DateTimeT : TypeT { public override string ToString() { return "Datetime"; }}
 
+public sealed record ErrorT(string Msg) : TypeT { public override string ToString() { return this.Msg; }};
+
 public sealed record CategoryT : TypeT { public override string ToString() { return "category"; }} // delete?

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata;
 using RAL.AST;
 
 namespace RAL.Interpreter;
@@ -20,22 +21,25 @@ Runtime checks are still used for cases such as division by zero.
 public class Interpreter {
     private const float Epsilon = 0.00001f;
 
+    //Evaluates a statement with pattern matching on the AST nodes
+
     public static void EvalStmt(Stmt stmt)
     {
         switch(stmt)
-        {
+        {   case Skip: break;
+           
+            case Composite c: HandleComposite(c); break;
+           
+            case If i: HandleIf(i); break;
+
+            case VarDecl vd: HandleVarDecl(vd); break;
+
             case ExpStmt s: Console.WriteLine(EvalExp(s.Expression)); break;
-
-            case Composite c: {
-                if(c.Stmt1 != null) EvalStmt(c.Stmt1);
-                if(c.Stmt2 != null) EvalStmt(c.Stmt2);
-                break;
-            }
-
-            default: throw new Exception($"Unknown statement.");
+            default: throw new Exception($"Unknown Statement:" + stmt.ToString());
         }
     }
 
+    //Evaluates and returns an expression. Pattern matching on the AST nodes
     public static Value EvalExp(Exp exp) {
         return exp switch {
             NumberV n => new NumberVal(n.Value),
@@ -51,19 +55,32 @@ public class Interpreter {
         };
     }
 
-    static private Value EvalUnary(UnaryOperation exp) {
-        Value value = EvalExp(exp.Expression);
-
-        return exp.Operator switch {
-            UnaryOperator.NOT when value is BoolVal b
-                => new BoolVal(!b.Value),
-            
-            UnaryOperator.NEG when value is NumberVal n
-                => new NumberVal(-n.Value),
-
-            _ => throw new Exception($"Line {exp.LineNumber}: Invalid unary operation.")
-        };
+    /* ________________________Statement Handlers______________________________*/
+    
+    static private void HandleComposite (Composite c) {
+        // Evaluates left subtree first
+        if(c.Stmt1 != null) EvalStmt(c.Stmt1);
+        // Right subtree
+        if(c.Stmt2 != null) EvalStmt(c.Stmt2);        
     }
+
+    static private void HandleIf(If ifNode) {
+        //Evaluate condition to interpreter values
+        Value condition = EvalExp(ifNode.Condition);
+
+        //Downcast and extract bool value, guarenteed by typechecking. Bodies will be skip
+        if (condition.AsBool())
+            EvalStmt(ifNode.ThenBody); //will be skip if empty {}
+        else 
+            EvalStmt(ifNode.ElseBody); //will be skip if excluded or empty {}
+    }
+
+    static private void HandleVarDecl(VarDecl vdNode) {
+
+                
+    }
+
+    /*_____________________Expression Handlers_____________________*/
 
     static private Value EvalBinary(BinaryOperation exp) {
         Value left = EvalExp(exp.LeftExpression);
@@ -200,6 +217,23 @@ public class Interpreter {
             _ => throw new Exception($"Line {exp.LineNumber}: Invalid binary operation.")
         };
     }
+
+    static private Value EvalUnary(UnaryOperation exp) {
+
+        //Evaluate inner expression
+        Value value = EvalExp(exp.Expression);
+
+        return exp.Operator switch {
+            UnaryOperator.NOT when value is BoolVal b
+                => new BoolVal(!b.Value),
+            
+            UnaryOperator.NEG when value is NumberVal n
+                => new NumberVal(-n.Value),
+
+            _ => throw new Exception($"Line {exp.LineNumber}: Invalid unary operation.")
+        };
+    }
+
 
     private static NumberVal DivideNumbers(NumberVal left, NumberVal right, int lineNumber) {
         CheckDivisionByZero(right.Value, lineNumber);

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -17,7 +17,13 @@ using System.Globalization;
 */
 
 
-public abstract record Value {}
+public abstract record Value
+{
+    /*Default methods to avoid poluting interpreter.cs with downcasts. 
+      Typechecking should have guarded possible exceptions */
+    public bool AsBool()  => ((BoolVal)this).Value; 
+    
+}
 
 /* For now, Number is represented as float because the language 
    uses one Number type for both integer-like and decimal values. */

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -1,4 +1,6 @@
 namespace RAL.Interpreter;
+
+using System.ComponentModel;
 using System.Globalization;
 
 /* Runtime values used by the interpreter.
@@ -39,7 +41,7 @@ record StringVal(string Value) : Value
 /*________________ Time ______________*/
 record DateTimeVal(DateTime Value) : Value
 {
-    // Returns the DateTime formatted as "dd/MM-yyyy HH:mm" using French (fr-FR) culture.
+    // Returns the DateTime formatted as custom "dd/MM-yyyy HH:mm" using French (fr-FR) culture.
     public override string ToString() => Value.ToString("dd/MM-yyyy HH:mm", new CultureInfo("fr-FR"));
 }
 
@@ -47,3 +49,27 @@ record DurationVal(TimeSpan Value) : Value
 {
     public override string ToString() => Value.ToString();
 }
+
+/*
+
+//EnvV, EnvF, EnvH
+
+//CategoryId for move to avoid linear search of every list in Categories,     property id -> value
+record ResourceVal(string ResourceId, string CategoryId, Dictionary<string , Value> Properties) : Value;
+
+//CategoryId -> Resources within it. EnvH is still needed.
+Dictionary<string, List<ResourceVal>> ResourcesByCategory
+
+
+
+// 2 DoubleRoom dr and 3 Room ... time ...
+//Alternative one resourceVal and make it composite reservation i.e. ReservationVal, drawback cannot reschedule
+record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateTimeVal End );
+
+//All reservations treated equally like this. An atomic reservation, has a list length 1
+record ReservationVal( List<ReservationAtomVal> Reservations) : Value;
+
+
+//   
+List<ReservationVal> Calendar = new();
+*/

--- a/src/RAL/Program.cs
+++ b/src/RAL/Program.cs
@@ -33,7 +33,7 @@ class Program {
 
             TypeChecker typeChecker = new TypeChecker();
 
-            typeChecker.StmtType(program, new EnvV(), new EnvC(), new EnvH(), new EnvT(), new EnvR());
+            typeChecker.StmtType(program, new EnvV(), new EnvC(), new EnvH(), new EnvT(), new EnvR(), new EnvCPT());
 
             //Console.WriteLine("\n\n\n\nProgram:\n"+ program.ToString() + "\n\n\n\n\n");
 

--- a/src/RAL/TypeChecker/EnvC.cs
+++ b/src/RAL/TypeChecker/EnvC.cs
@@ -9,8 +9,11 @@ public class EnvC {
         return C.Contains(category);
     }
 
-    public void AddCategory(string category) {
-        if(CategoryIsDeclared(category)) throw new Exception($"Category '{category}' has already been declared");
+    public bool AddCategory(string category) {
+        if(CategoryIsDeclared(category)) 
+            return false;
+            
         C.Add(category);
+        return true;
     }
 }

--- a/src/RAL/TypeChecker/EnvCPT.cs
+++ b/src/RAL/TypeChecker/EnvCPT.cs
@@ -1,0 +1,69 @@
+namespace RAL.TC;
+
+using System.Diagnostics.Metrics;
+using RAL.AST;
+
+//// <summary> categoryId x propertyId -> type. 
+/// Typing environment for properties defined within a category.
+/// For a given category, a property identifier must always be associated with the same type across all resources in that category.
+/// Purpose: Support static type-checking of "where" condition within queries containing a*rc ident </summary>
+public class EnvCPT {
+    //                       categoryId         { propertyId, TypeT }
+    private readonly Dictionary<string, Dictionary<string, TypeT>> CPT = new(); 
+
+    public void Bind(string categoryId, string propertyId, TypeT type) {
+        
+        //Lazy addition of Category to environment. Only add when a property needs binding
+        if(!CPT.ContainsKey(categoryId)) {
+            CPT.Add(categoryId, new Dictionary<string, TypeT>());
+        } 
+        
+        //Extract inner map
+        Dictionary<string, TypeT> propertyTypeMap = CPT[categoryId];
+
+        //Checked other places, throw exception if reached
+        if(propertyTypeMap.ContainsKey(propertyId)) {
+            throw new Exception($"Property {propertyId} already exists within Category {categoryId} !");
+        }
+
+        propertyTypeMap.Add(propertyId, type);
+
+    }
+
+    //Returns the type 
+    public TypeT Lookup(string categoryId, string propertyId) {
+
+        Dictionary<string, TypeT> propertyTypeMap = GetPropertyTypeMap(categoryId);
+        
+        //Fetch type, throw exception if propertyId is not in the map
+        if(!propertyTypeMap.TryGetValue(propertyId, out TypeT type)) {
+            throw new Exception("Eror!!");
+        }
+
+        return type;
+    }
+
+        /// <summary> Returns inner map of categoryId, throws exception if not registered </summary>
+    public Dictionary<string, TypeT> GetPropertyTypeMap (string categoryId)
+    {
+        //Guard invalid categoryId. tryGetValue returns false if dictionary did not contain key 'categoryId'.
+        if(CPT.TryGetValue(categoryId, out Dictionary<string, TypeT> propertyTypeMap) == false) {
+            throw new Exception($"Invalid categoryId: '{categoryId}' argument!");
+        }
+
+        //Key: CategoryID valid, 'propertyTypeMap' contains value: dictionary<propertyId -> type>
+        return propertyTypeMap;
+    }
+
+    //Boolean function checking wether a property exists within a category
+    public bool HasProperty(string categoryId, string propertyId) {
+        return HasCategory(categoryId) && GetPropertyTypeMap(categoryId).ContainsKey(propertyId);
+    }
+
+    public bool HasCategory(string categoryId)
+    {
+        return CPT.ContainsKey(categoryId); 
+    
+    }
+
+}

--- a/src/RAL/TypeChecker/EnvCPT.cs
+++ b/src/RAL/TypeChecker/EnvCPT.cs
@@ -1,6 +1,4 @@
 namespace RAL.TC;
-
-using System.Diagnostics.Metrics;
 using RAL.AST;
 
 //// <summary> categoryId x propertyId -> type. 
@@ -44,8 +42,7 @@ public class EnvCPT {
     }
 
         /// <summary> Returns inner map of categoryId, throws exception if not registered </summary>
-    public Dictionary<string, TypeT> GetPropertyTypeMap (string categoryId)
-    {
+    public Dictionary<string, TypeT> GetPropertyTypeMap (string categoryId) {
         //Guard invalid categoryId. tryGetValue returns false if dictionary did not contain key 'categoryId'.
         if(CPT.TryGetValue(categoryId, out Dictionary<string, TypeT> propertyTypeMap) == false) {
             throw new Exception($"Invalid categoryId: '{categoryId}' argument!");
@@ -60,8 +57,7 @@ public class EnvCPT {
         return HasCategory(categoryId) && GetPropertyTypeMap(categoryId).ContainsKey(propertyId);
     }
 
-    public bool HasCategory(string categoryId)
-    {
+    public bool HasCategory(string categoryId) {
         return CPT.ContainsKey(categoryId); 
     
     }

--- a/src/RAL/TypeChecker/EnvH.cs
+++ b/src/RAL/TypeChecker/EnvH.cs
@@ -5,24 +5,81 @@ using RAL.AST;
 public class EnvH {
 
     //Map: Each category to its immediate supertype. If none supplied at declaration, Root "Resource" is immediate super.
-    private readonly Dictionary<ResourceT, ResourceT> H = new(); // child --> parent
+    private readonly Dictionary<ResourceT, ResourceT?> parentCatRelations = new() { 
+        {new ResourceT("Resource"), null} 
+    }; 
 
+    /// <summary> Boolean lookup function "envH()": True if first argument is of same type or descendant of second </summary>
+    public bool IsSubtype(ResourceT childCat, ResourceT parentCat) {
 
-    /// <summary> Boolean function: True if first argument is descendant of second </summary>
-    public bool IsSubtype(ResourceT child, ResourceT parent) {
-
-        while (child != null) {
-            if (child == parent) 
+        while (childCat != null) {
+            if (childCat == parentCat) 
                 return true;
             
-            if (!H.TryGetValue(child, out child)) 
+            if (!parentCatRelations.TryGetValue(childCat, out childCat)) 
                 break;
         }
         return false;
     }
 
-    public void EstablishRelation(ResourceT child, ResourceT parent) {
-        if(child == parent) throw new Exception("A category may not relate to itself");
-        H[child] = parent;
+
+
+    public void EstablishRelation(ResourceT childCat, ResourceT parentCat) {
+        if(childCat == parentCat) throw new Exception("A category may not relate to itself");
+        parentCatRelations[childCat] = parentCat;
     } 
+
+/// <summary> Under valid input, guarentees parentCat. Nullable due to 'Resource' having no parentCat. Otherwise, throws exception <summary>
+    public ResourceT? GetParent (ResourceT childCat) {
+        
+        //Guard invalid childCat input. tryGetValue returns false if dictionary did not contain key 'childCat', parentCat would be null
+        if (parentCatRelations.TryGetValue(childCat, out ResourceT parentCat) == false)
+            throw new Exception("Invalid childCat argument to GetparentCat");
+       
+       //childCat input valid. 'parentCat' contains value at key 'childCat'
+        return parentCat;
+    }
+
+    //Returns a 'list' of all immediate children categories
+    public IEnumerable<ResourceT> GetChildren(ResourceT category) =>
+    parentCatRelations
+        .Where(kvp => kvp.Value == category)
+        .Select(kvp => kvp.Key);
+
+     public IEnumerable<ResourceT> GetAllRelated(ResourceT category) {
+        var result = new HashSet<ResourceT>();
+
+        //Upwards
+        ResourceT? current = category;
+        while (current != null) {
+            result.Add(current);
+            current = GetParent(current);
+        }
+
+        //Downwards
+        var stack = new Stack<ResourceT>(GetChildren(category));
+        while (stack.Count > 0) {
+            var node = stack.Pop();
+            if (result.Add(node))
+                foreach (var child in GetChildren(node))
+                    stack.Push(child);
+        }
+
+        return result;
+    }
+
+    // Used by: LookupCategoryPropertyType (reserve where-clause only)
+    public IEnumerable<ResourceT> GetSubtree(ResourceT category) {
+        var result = new HashSet<ResourceT>();
+        var stack = new Stack<ResourceT>();
+        stack.Push(category);
+        while (stack.Count > 0) {
+            var node = stack.Pop();
+            if (result.Add(node))
+                foreach (var child in GetChildren(node))
+                    stack.Push(child);
+        }
+        return result;
+    }
+
 }

--- a/src/RAL/TypeChecker/EnvH.cs
+++ b/src/RAL/TypeChecker/EnvH.cs
@@ -25,19 +25,14 @@ public class EnvH {
 
 
     public void EstablishRelation(ResourceT childCat, ResourceT parentCat) {
-        if(childCat == parentCat) throw new Exception("A category may not relate to itself");
+        // needs to be exception, otherwise lookups may enter infinite loop
+        if(childCat == parentCat) throw new Exception("A category may not relate to itself"); 
         parentCatRelations[childCat] = parentCat;
     } 
 
 /// <summary> Under valid input, guarentees parentCat. Nullable due to 'Resource' having no parentCat. Otherwise, throws exception <summary>
-    public ResourceT? GetParent (ResourceT childCat) {
-        
-        //Guard invalid childCat input. tryGetValue returns false if dictionary did not contain key 'childCat', parentCat would be null
-        if (parentCatRelations.TryGetValue(childCat, out ResourceT parentCat) == false)
-            throw new Exception("Invalid childCat argument to GetparentCat");
-       
-       //childCat input valid. 'parentCat' contains value at key 'childCat'
-        return parentCat;
+    public bool TryGetParent(ResourceT childCat, out ResourceT? parent) {
+        return parentCatRelations.TryGetValue(childCat, out parent);
     }
 
     //Returns a 'list' of all immediate children categories
@@ -46,14 +41,18 @@ public class EnvH {
         .Where(kvp => kvp.Value == category)
         .Select(kvp => kvp.Key);
 
-     public IEnumerable<ResourceT> GetAllRelated(ResourceT category) {
+     public IEnumerable<ResourceT>? GetAllRelated(ResourceT category) {
         var result = new HashSet<ResourceT>();
 
         //Upwards
         ResourceT? current = category;
         while (current != null) {
             result.Add(current);
-            current = GetParent(current);
+            if (!TryGetParent(current, out ResourceT? parent)) {
+                return null;
+            }
+
+            current = parent;
         }
 
         //Downwards

--- a/src/RAL/TypeChecker/EnvH.cs
+++ b/src/RAL/TypeChecker/EnvH.cs
@@ -42,26 +42,24 @@ public class EnvH {
         .Select(kvp => kvp.Key);
 
      public IEnumerable<ResourceT>? GetAllRelated(ResourceT category) {
+        //Set of all related nodes, ancesters and decendants
         var result = new HashSet<ResourceT>();
 
-        //Upwards
+        //Upwards, ancesters
         ResourceT? current = category;
         while (current != null) {
             result.Add(current);
             if (!TryGetParent(current, out ResourceT? parent)) {
+                //Indicates invalid input
                 return null;
             }
 
             current = parent;
         }
-
-        //Downwards
-        var stack = new Stack<ResourceT>(GetChildren(category));
-        while (stack.Count > 0) {
-            var node = stack.Pop();
-            if (result.Add(node))
-                foreach (var child in GetChildren(node))
-                    stack.Push(child);
+        
+        // Downwards, descendants
+        foreach (ResourceT node in GetSubtree(category)) {
+            result.Add(node);
         }
 
         return result;
@@ -72,6 +70,7 @@ public class EnvH {
         var result = new HashSet<ResourceT>();
         var stack = new Stack<ResourceT>();
         stack.Push(category);
+        
         while (stack.Count > 0) {
             var node = stack.Pop();
             if (result.Add(node))

--- a/src/RAL/TypeChecker/EnvR.cs
+++ b/src/RAL/TypeChecker/EnvR.cs
@@ -6,7 +6,7 @@ using RAL.AST;
 /// </summary> 
 public class EnvR {
 
-    ///Main data structure. R = ResourceId -> (FieldId -> Type)
+    ///Main data structure. R = ResourceId -> (PropertyId -> Type)
     private readonly Dictionary<string, Dictionary<string, TypeT>> R = new();
 
     /// <summary> All resources must be registered. Whether fields or not  /// </summary>
@@ -39,6 +39,8 @@ public class EnvR {
 
         //Bind type to field
         fieldEnvironment.Add(fieldId, type);
+
+        Console.WriteLine("EnvR Binding " + resourceId + "," + fieldId + "->"+ type + "\n");
     }
 
     public TypeT LookupField(string resourceId, string fieldName) {
@@ -52,5 +54,17 @@ public class EnvR {
             return fieldType;
 
         throw new Exception($"Unknown field '{fieldName}' in resource '{resourceId}'.");
+    }
+
+     /// <summary> Returns inner map of categoryId, throws exception if not registered </summary>
+    public Dictionary<string, TypeT> GetPropertyTypeMap (string resourceId)
+    {
+        //Guard invalid categoryId. tryGetValue returns false if dictionary did not contain key 'categoryId'.
+        if(R.TryGetValue(resourceId, out Dictionary<string, TypeT> propertyTypeMap) == false) {
+            throw new Exception($"Invalid Resource: '{resourceId}' argument!");
+        }
+
+        //Key: CategoryID valid, 'propertyTypeMap' contains value: dictionary<propertyId -> type>
+        return propertyTypeMap;
     }
 }

--- a/src/RAL/TypeChecker/EnvR.cs
+++ b/src/RAL/TypeChecker/EnvR.cs
@@ -28,32 +28,31 @@ public class EnvR {
     }
 
     /// <summary> Associates a resource </summary> 
-    public void BindField(string resourceId, string fieldId, TypeT type) {
+    public bool BindField(string resourceId, string fieldId, TypeT type) {
   
         //Retrieve the relevant resource's field environment (nest)
         Dictionary<string, TypeT> fieldEnvironment = R[resourceId];
 
         //Guard against the resource containing duplicate field id's
         if (fieldEnvironment.ContainsKey(fieldId))
-            throw new Exception($"Field '{fieldId}' is already defined in resource '{resourceId}'.");
+            return false;
 
         //Bind type to field
         fieldEnvironment.Add(fieldId, type);
-
-        Console.WriteLine("EnvR Binding " + resourceId + "," + fieldId + "->"+ type + "\n");
+        return true;
     }
 
-    public TypeT LookupField(string resourceId, string fieldName) {
+    public TypeT? LookupField(string resourceId, string fieldName) {
 
         // Check if the resource has been declared. If it has, return it's inner dictionary mapping field -> type
         if (!R.TryGetValue(resourceId, out Dictionary<string, TypeT> fieldEnvironment)) 
-            throw new Exception($"Unknown resource '{resourceId}'.");
+            return null;
 
         // Do a lookup in the inner dictionary, getting the type of the field
         if (fieldEnvironment.TryGetValue(fieldName, out TypeT fieldType)) 
             return fieldType;
 
-        throw new Exception($"Unknown field '{fieldName}' in resource '{resourceId}'.");
+        return null;
     }
 
      /// <summary> Returns inner map of categoryId, throws exception if not registered </summary>

--- a/src/RAL/TypeChecker/EnvT.cs
+++ b/src/RAL/TypeChecker/EnvT.cs
@@ -5,19 +5,20 @@ using RAL.AST;
 public class EnvT {
     private readonly Dictionary<string, List<TypeT>> T = new();
 
-    public void Bind(string var, List<TypeT> types) {
+    public bool Bind(string var, List<TypeT> types) {
         if (T.ContainsKey(var)) {
-            throw new Exception($"Template '{var}' already declared.");
+            return false;
         }
 
-        T[var] = types;
+        T.Add(var, types);
+        return true;
     }
 
-    public List<TypeT> Lookup(string var) {
+    public List<TypeT>? Lookup(string var) {
         if (T.TryGetValue(var, out List<TypeT> types)) {
             return types;
         } else {
-            throw new Exception($"Use of undeclared template: '{var}'.");
+            return null;
         }
     }
 }

--- a/src/RAL/TypeChecker/EnvV.cs
+++ b/src/RAL/TypeChecker/EnvV.cs
@@ -21,6 +21,8 @@ public class EnvV {
         }
 
         V[var] = type;
+
+        Console.WriteLine("EnvV Binding " + var + " to: " + V[var] + "\n");
     }
 
     public void ChangeCategory(string var, TypeT type) {
@@ -60,23 +62,5 @@ public class EnvV {
 
         //Return global scope
         return current;
-    }
-
-    ///<summary> Returns a list of all ids of variablesthat are of (or subtype of) the provided category /// </summary>
-    public List<string> GetResourcesByCategory(ResourceT category, EnvV envV, EnvH envH) {
-        List<string> resourceIds = new();
-
-        //Resources are only declarable in global scope, traverse til there
-        EnvV globalScope = envV.GetGlobalScope();
-        
-        // Check current scope
-        foreach (KeyValuePair<string, TypeT> pair in globalScope.V) {
-            //Pattern match on those elements of resource types, add the 
-            if (pair.Value is ResourceT resource && envH.IsSubtype(resource, category)) {
-                resourceIds.Add(pair.Key);
-            }
-        }
-
-        return resourceIds;
     }
 }

--- a/src/RAL/TypeChecker/EnvV.cs
+++ b/src/RAL/TypeChecker/EnvV.cs
@@ -15,32 +15,32 @@ public class EnvV {
         return new EnvV(this);
     }
 
-    public void Bind(string var, TypeT type) {
+    public bool Bind(string var, TypeT type) {
         if (V.ContainsKey(var)) {
-            throw new Exception($"Variable '{var}' already declared in current scope.");
+            return false;
         }
 
-        V[var] = type;
-
-        Console.WriteLine("EnvV Binding " + var + " to: " + V[var] + "\n");
+        V.Add(var, type);
+        return true;
     }
 
-    public void ChangeCategory(string var, TypeT type) {
+    public bool ChangeCategory(string var, TypeT type) {
         if (V.ContainsKey(var)) {
             V[var] = type;
+            return true;
         } else {
-            throw new Exception($"Use of undeclared variable: '{var}'.");
+            return false;
         }
     }
 
-    public TypeT Lookup(string var) {
+    public TypeT? Lookup(string var) {
         if (V.TryGetValue(var, out TypeT type)) 
             return type;
 
         if (parent != null) 
             return parent.Lookup(var);
         
-        throw new Exception($"Use of undeclared variable: '{var}'.");
+        return null;
     }
 
     // unneeded

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using RAL.AST;
 using RAL.Interpreter;
 namespace RAL.TC;
@@ -62,7 +63,7 @@ class TypeChecker {
             UnaryOperation u => HandleUnary(u, envV, envC, envH, envT, envR, envCPT),
 
 
-            _ => throw new Exception($"Unknown {exp.LineNumber} expression.") // should never happen
+            _ => throw new Exception($"Unknown expression.") // should never happen
         };
 
 /* ________________________Statement Handlers______________________________*/
@@ -82,19 +83,19 @@ class TypeChecker {
 
     private void HandleVarDecl(VarDecl decl, EnvV envV, EnvC envC) {
         if(decl.Type is ResourceT r && !envC.CategoryIsDeclared(r.Category))
-            throw new Exception($"Use of undeclared category '{r.ToString()}'.");
+            errors.Add($"Use of undeclared category '{r.ToString()}'.");
    
-        envV.Bind(decl.Identifier, decl.Type);
+        bool bound = envV.Bind(decl.Identifier, decl.Type);
+        if(!bound) errors.Add($"Variable '{decl.Identifier}' already declared in current scope.");
     }
 
 
     private void HandleCategoryDecl(CategoryDecl cd, EnvC envC, EnvH envH) {
-        //Ensure id is not already in the set of categories
-        if(envC.CategoryIsDeclared(cd.CategoryId))
-            errors.Add($"Category '{cd.CategoryId}' has already been declared.");
 
-        //Add the new category to the set
-        envC.AddCategory(cd.CategoryId);
+        // Add the new category to the set; function returns bool indicating whether category has already been declared
+        if(envC.AddCategory(cd.CategoryId) == false) {
+            errors.Add($"Category '{cd.CategoryId}' has already been declared.");
+        }
 
         //Handle relation to parent - 'is a id' part of [category id is a id]. If no relation is explicitly provided, parent is 'Resource'
         if(cd.ParentId == null) {
@@ -103,7 +104,7 @@ class TypeChecker {
             
             //Ensure parent is in the set of categories
             if(!envC.CategoryIsDeclared(cd.ParentId)) 
-                throw new Exception($"Use of undeclared category '{cd.ParentId}'.");
+                errors.Add($"Use of undeclared category '{cd.ParentId}'.");
 
             //Delegate establishment of parent relation to hierarchy environment. Guards cyclic relations
             envH.EstablishRelation(new ResourceT(cd.CategoryId), new ResourceT(cd.ParentId)); 
@@ -118,7 +119,8 @@ class TypeChecker {
         else if(!envC.CategoryIsDeclared(r.Category))
             errors.Add($"Use of undeclared category '{r.Category}'");
         
-        envV.Bind(resDecl.Identifier, resDecl.Type); // bind resource to variable environment
+        bool bound = envV.Bind(resDecl.Identifier, resDecl.Type); // bind resource to variable environment
+        if(!bound) errors.Add($"Variable '{resDecl.Identifier}' already declared in current scope.");
 
         envR.RegisterResource(resDecl.Identifier); // Invariant: All resources must be registered in resource environment, important for property checking
 
@@ -153,13 +155,14 @@ class TypeChecker {
         } else {
 
             //A new scope is passed so within the resource envV is used as lookup, when assigning
-            if(withAssignment)
-            {
-                envV.Bind(varDecl.Identifier, varDecl.Type);  
+            if(withAssignment) {
+                bool bound = envV.Bind(varDecl.Identifier, varDecl.Type);  
+                if(!bound) errors.Add($"Variable '{varDecl.Identifier}' already declared in current scope.");
             }
 
             //For use outside resource
-            envR.BindField(resDecl.Identifier, varDecl.Identifier, varDecl.Type);
+            bool boundR = envR.BindField(resDecl.Identifier, varDecl.Identifier, varDecl.Type);
+            if(!boundR) errors.Add($"Property '{varDecl.Identifier}' has already been declared.");
 
              //
             CheckCategoryPropertyConflict(resDecl.Type, varDecl.Identifier, varDecl.Type, envH, envCPT);
@@ -169,14 +172,20 @@ class TypeChecker {
 
      private void CheckCategoryPropertyConflict(ResourceT resDeclType, string propertyId, TypeT incomingType, EnvH envH, EnvCPT envCPT) {
 
+        IEnumerable<ResourceT>? relatedList = envH.GetAllRelated(resDeclType);
 
-        foreach (ResourceT related in envH.GetAllRelated(resDeclType))
-        {
+        if(relatedList == null) {
+            errors.Add($"Use of undeclared category '{resDeclType.Category}'"); // message WIP
+            return;
+        }
+
+        foreach (ResourceT related in relatedList) {
             //Case 1: the property does not exist within current category
             if (!envCPT.HasProperty(related.Category, propertyId))
                  continue; //Skips rest of loop
             
             //Case 2: If this is reached. 2 The proper propertyId within category is of a different type than the declaration: Ok
+            // No need to guard against failed lookup; will never fail given the property check above
             TypeT existingType = envCPT.Lookup(related.Category, propertyId);
 
             //2-fail: propertyId within category is of a different type than the declaration: Ok
@@ -188,14 +197,15 @@ class TypeChecker {
                 );
             }
                 
-            return; // found in tree — consistent or error logged; do not bind again
+            return; // found in tree, consistent or error logged; do not bind again
         }
-         //2.Success New to entire tree — register it
+         // 2.Success New to entire tree, register it
+         // No need to guard against failed bind; will never reach here if it is already bounded given the above return
         envCPT.Bind(resDeclType.Category, propertyId, incomingType);
      }
 
     private void HandleTemplateDecl(TemplateDecl tmplDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
-        if(tmplDecl.ParamList == null) return; // possible problems in template lookup due to null pointer dereference?
+        if(tmplDecl.ParamList == null) return;
 
         EnvV tmplScope = envV.NewScope();
         List<TypeT> paramTypes = new();
@@ -204,14 +214,15 @@ class TypeChecker {
             paramTypes.Add(param.Type); // extract types from param list and add to template environment
             tmplScope.Bind(param.Identifier, param.Type); // make formal parameters accessible (only) in template body
         }
-        envT.Bind(tmplDecl.TemplateId, paramTypes); // bind template id to formal param types
+        bool bound = envT.Bind(tmplDecl.TemplateId, paramTypes); // bind template id to formal param types
+        if(!bound) errors.Add($"Template '{tmplDecl.TemplateId}' already declared.");
 
         if(tmplDecl.TemplateBody != null) 
             StmtType(tmplDecl.TemplateBody, tmplScope, envC, envH, envT, envR, envCPT); // type check body. 
     }
 
     private void HandleTemplateCall(TemplateCall tc, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
-        List<TypeT> formalParamTypes = envT.Lookup(tc.TemplateId);
+        List<TypeT>? formalParamTypes = envT.Lookup(tc.TemplateId);
 
         if(formalParamTypes == null && tc.ArgList == null) return; // both lists are empty; illtyping is impossible
 
@@ -242,12 +253,13 @@ class TypeChecker {
     private void HandleMove(Move move, EnvV envV, EnvC envC, EnvH envH ,EnvR envR, EnvCPT envCPT) {
 
         // Ensure id to move maps to a resource. V(r) = Resource. 
-        TypeT type = envV.Lookup(move.ResourceId);
+        TypeT? type = envV.Lookup(move.ResourceId);
+        if(type == null) errors.Add($"Use of undeclared variable '{move.ResourceId}'.");
         if(type is ResourceT) {
 
             //Ensure id of category maps to a category
             if(!envC.CategoryIsDeclared(move.Type.Category)) 
-                throw new Exception($"Use of undeclared category '{move.Type.Category}'.");
+                errors.Add($"Use of undeclared category '{move.Type.Category}'.");
             
             //Before moving check for conflicts between the resource's property types and those of the category
             Dictionary<string, TypeT> propertyTypeMap = envR.GetPropertyTypeMap(move.ResourceId);
@@ -258,7 +270,9 @@ class TypeChecker {
             }
 
             //Currently moving wether or not conflicts occur
-            envV.ChangeCategory(move.ResourceId, new ResourceT(move.Type.Category));
+            if(envV.ChangeCategory(move.ResourceId, new ResourceT(move.Type.Category)) == false) {
+                errors.Add($"Use of undeclared variable: '{move.ResourceId}'.");
+            }
 
         } else 
             errors.Add($"Expected type 'Resource' got '{type.ToString()}'");
@@ -312,13 +326,16 @@ class TypeChecker {
                 }
 
                 if (resourceSpec.Identifier != null) {
-                    envV.Bind(resourceSpec.Identifier, new ResourceT(resourceSpec.CategoryId));
+                    bool bound = envV.Bind(resourceSpec.Identifier, new ResourceT(resourceSpec.CategoryId));
+                    if(!bound) errors.Add($"Variable '{resourceSpec.Identifier}' already declared in current scope.");
                 }
             }
 
             // "id"
             else if (resourceSpec.Identifier != null && resourceSpec.Quantity == null) {
-                if (envV.Lookup(resourceSpec.Identifier) is not ResourceT) {
+                TypeT? type = envV.Lookup(resourceSpec.Identifier);
+                if(type == null) errors.Add($"Use of undeclared variable '{resourceSpec.Identifier}'");
+                if (type is not ResourceT) {
                     errors.Add($"Expected type 'Resource' got '{resourceSpec.Identifier}'");
                     isWellTyped = false;
                 }
@@ -340,7 +357,7 @@ class TypeChecker {
         return (fromType, toType) switch {
             (DateTimeT, DateTimeT) => true, // dt to dt
             (DateTimeT, DurationT) => true, // dt for dur
-            _  => Error($"Types {fromType.ToString()} and {toType.ToString()} incompatible with interval expression")
+            _  => Error($"Types {fromType.ToString()} and {toType.ToString()} incompatible with interval expression", false)
         };
     }
 
@@ -350,7 +367,7 @@ class TypeChecker {
         TypeT condType = ExpType(condition, envV, envC, envH, envT, envR, envCPT);
         return condType switch {
             BoolT => true,
-            _  => Error($"Condition expected type 'bool' got '{condType.ToString()}'")
+            _  => Error($"Condition expected type 'bool' got '{condType.ToString()}'", false)
         };
     }
 
@@ -362,7 +379,7 @@ class TypeChecker {
         return (everyType, endType) switch {
             (DurationT, DateTimeT) => true, // needs way to distinguish between for/until
             (DurationT, DurationT) => true,
-            _  => Error($"Types '{everyType.ToString()}' and '{endType.ToString()}' incompatible for recurrence.")       
+            _  => Error($"Types '{everyType.ToString()}' and '{endType.ToString()}' incompatible for recurrence.", false)       
         };
     }    
     
@@ -383,7 +400,9 @@ class TypeChecker {
     {
         //id case
         if (referenceNode.PropertyId == null) {
-            return envV.Lookup(referenceNode.VariableId);
+            TypeT? type = envV.Lookup(referenceNode.VariableId);
+            if(type == null) return Error($"Use of undeclared variable '{referenceNode.VariableId}'.");
+            return type;
         }
         //id.id case   
         else {
@@ -394,17 +413,20 @@ class TypeChecker {
     private TypeT HandlePropertyReference(Reference reference, EnvV envV, EnvH envH, EnvR envR, EnvCPT envCPT) {
         
         //Guard: Ensure that the variable is a resource type. Only these should allow property access.
-        TypeT varType = envV.Lookup(reference.VariableId);
+        TypeT? varType = envV.Lookup(reference.VariableId);
+        if(varType == null) return Error($"Use of undeclared variable '{reference.VariableId}'.");
  
         if (varType is not ResourceT resource) {
-            return Error($"Cannot access property '{reference.PropertyId}' on non-resource '{reference.VariableId}'.", new BoolT());
+            return Error($"Cannot access property '{reference.PropertyId}' on non-resource '{reference.VariableId}'.");
         }
 
         // Case 1: Declared resources. Upon declaration, reglardless of having fields, a resource is registered to envR.
         if (envR.HasResource(reference.VariableId)) {
 
             // id.id cases.'PropertyId' can never be null given case from which this method is invoked in HandleReference
-            return envR.LookupField(reference.VariableId, reference.PropertyId);
+            TypeT? type = envR.LookupField(reference.VariableId, reference.PropertyId);
+            if(type == null) return Error($"Property '{reference.PropertyId}' doesn't exist in resource '{reference.VariableId}'");
+            return type;
         }
 
         // Case 2: Does not exist in resource environment -> Bounded query variable. Check envCPT categoryId x propertyId -> Type
@@ -422,17 +444,15 @@ class TypeChecker {
             }
         }
 
-        return Error(
-            $"No resource in the category tree of '{category.Category}' " +
-            $"declares a field '{propertyId}'.",
-            new BoolT()
-        );
+        return Error($"No resource in the category tree of '{category.Category}' declares a field '{propertyId}'.");
     }
 
      private TypeT HandleAssignment(Assignment assign, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         TypeT varType = HandleReference(assign.Variable, envV, envH, envR, envCPT);
-
         TypeT expType = ExpType(assign.Value, envV, envC, envH, envT, envR, envCPT);
+
+        if (varType is ErrorT) return varType;
+        if (expType is ErrorT) return expType;
         
         if (varType is ResourceT) 
             errors.Add($"Assignment of expression to resource not allowed");
@@ -450,17 +470,22 @@ class TypeChecker {
         TimeSpecIsWellTyped(r.NewTimeInterval, envV, envC, envH, envT, envR, envCPT); // Simply checks for errors in the [dt to dt / for dur]. Return value is discarded
 
         TypeT expType = ExpType(r.Reservation, envV, envC, envH, envT, envR, envCPT);
+
+        if (expType is ErrorT) return expType;
+
+        if(expType is ReservationT) return new ReservationT();
+        return Error($"Reschedule expected type 'Reservation' got '{expType}'");
         
-        return expType switch {
-            ReservationT => new ReservationT(),
-            _ => Error($"Reschedule expected type 'Reservation' got '{expType}'", new ReservationT())
-        };
     }
 
     private TypeT HandleBinary(BinaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         
         TypeT left  = ExpType(exp.LeftExpression,  envV, envC, envH, envT, envR, envCPT);
         TypeT right = ExpType(exp.RightExpression, envV, envC, envH, envT, envR, envCPT);
+
+        // Propegate error upwards
+        if (left is ErrorT) return left;
+        if (right is ErrorT) return right;
         
         string operatorAsString = EnumToOp(exp.Operator);
         return exp.Operator switch
@@ -470,13 +495,13 @@ class TypeChecker {
             BinaryOperator.SUB => (left, right) switch {
                 (NumberT, NumberT)     => new NumberT(),   // num + num
                 (DateTimeT, DurationT) => new DateTimeT(), // dt + dur
-                _  => Error($"Line {exp.LeftExpression.LineNumber}: Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new NumberT())},
+                _  => Error($"Line {exp.LeftExpression.LineNumber}: Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
 
             // * /
             BinaryOperator.MUL or 
             BinaryOperator.DIV => (left, right) switch {
                 (NumberT, NumberT) => new NumberT(), // num */ num
-                _  => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new NumberT())},
+                _  => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
             
             // <, >, 
             BinaryOperator.LT   or // <
@@ -486,7 +511,7 @@ class TypeChecker {
                 (NumberT, NumberT) => new BoolT(),
                 (DateTimeT, DateTimeT) => new BoolT(),
                 (DurationT, DurationT) => new BoolT(),
-                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new BoolT())},
+                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
 
             BinaryOperator.EQ or 
             BinaryOperator.NEQ => (left, right) switch {
@@ -495,16 +520,16 @@ class TypeChecker {
                 (NumberT, NumberT) => new BoolT(),
                 (DurationT, DurationT) => new BoolT(),
                 (DateTimeT, DateTimeT) => new BoolT(),
-                _  => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new BoolT())},
+                _  => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
 
             BinaryOperator.OR or BinaryOperator.AND => (left, right) switch {
                 (ReservationT, ReservationT) => new ReservationT(), // reserve [...] and reserve [...]
                 (BoolT, BoolT)               => new BoolT(),        // 4 < 7 and 7 < 11
-                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new ReservationT())},
+                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
 
             BinaryOperator.SEQ => (left, right) switch {
                 (ReservationT, ReservationT) => new ReservationT(),
-                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'", new ReservationT())},
+                _ => Error($"Operand types '{left}' and '{right}' incompatible for '{operatorAsString}'")},
 
             _ => throw new Exception("Unknown binary operator.") // should never happen      
         };
@@ -512,13 +537,16 @@ class TypeChecker {
 
     private TypeT HandleUnary(UnaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         TypeT operandType = ExpType(exp.Expression, envV, envC, envH, envT, envR, envCPT);
+
+        if (operandType is ErrorT) return operandType;
+
         string operatorAsString = EnumToOp(exp.Operator);
         return exp.Operator switch {
             UnaryOperator.NOT when (operandType is BoolT) => new BoolT(),
-            UnaryOperator.NOT => Error($"Operator '{operatorAsString}' expected 'Bool' got '{operandType}'", new BoolT()),
+            UnaryOperator.NOT => Error($"Operator '{operatorAsString}' expected 'Bool' got '{operandType}'"),
 
             UnaryOperator.NEG when (operandType is NumberT) => new NumberT(),
-            UnaryOperator.NEG => Error($"Operator '{operatorAsString}' expected 'Number' got '{operandType}'", new NumberT()),
+            UnaryOperator.NEG => Error($"Operator '{operatorAsString}' expected 'Number' got '{operandType}'"),
             
             _ => throw new Exception("Unknown unary operator.") // should never happen
         };
@@ -527,14 +555,14 @@ class TypeChecker {
     /* ____________________________Errors and message helpers____________________________*/
 
      // Below two error functions are simply to circumvent switch expression limitations of not being able to add statements
-    private bool Error(string msg) {
+    private bool Error(string msg, bool value) {
         errors.Add(msg);
-        return false;
+        return value;
     }
 
-    private TypeT Error(string msg, TypeT fallback) {
+    private ErrorT Error(string msg) {
         errors.Add(msg);
-        return fallback;
+        return new ErrorT(msg);
     }
 
     private string EnumToOp(BinaryOperator op) {

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -1,46 +1,47 @@
 using RAL.AST;
+using RAL.Interpreter;
 namespace RAL.TC;
 
 class TypeChecker {
 
     public List<string> errors = new();
 
-    public void StmtType(Stmt stmt, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    public void StmtType(Stmt stmt, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         switch(stmt) {
             case Skip: break;
             
-            case Composite cmp: HandleComposite(cmp, envV, envC, envH, envT, envR); break;
+            case Composite cmp: HandleComposite(cmp, envV, envC, envH, envT, envR, envCPT); break;
             
-            case If i: HandleIf(i, envV, envC, envH, envT, envR); break;
+            case If i: HandleIf(i, envV, envC, envH, envT, envR, envCPT); break;
 
             case VarDecl decl: HandleVarDecl(decl, envV, envC); break;
 
 
             case CategoryDecl cd: HandleCategoryDecl(cd, envC, envH); break;
 
-            case ResourceDecl rd: HandleResourceDecl(rd, envV, envC, envH, envT, envR); break;
+            case ResourceDecl rd: HandleResourceDecl(rd, envV, envC, envH, envT, envR, envCPT); break;
 
             
-            case TemplateDecl tmplDecl: HandleTemplateDecl(tmplDecl, envV, envC, envH, envT, envR); break;
+            case TemplateDecl tmplDecl: HandleTemplateDecl(tmplDecl, envV, envC, envH, envT, envR, envCPT); break;
 
-            case TemplateCall tc: HandleTemplateCall(tc, envV, envC, envH, envT, envR); break;
+            case TemplateCall tc: HandleTemplateCall(tc, envV, envC, envH, envT, envR, envCPT); break;
 
 
-            case Move mv: HandleMove(mv, envV, envC); break; 
+            case Move mv: HandleMove(mv, envV, envC, envH, envR, envCPT); break; //envCPT
 
-            case Cancel c: HandleCancel(c, envV, envC, envH, envT, envR); break;
+            case Cancel c: HandleCancel(c, envV, envC, envH, envT, envR, envCPT); break;
             
 
-            case ExpStmt s: ExpType(s.Expression, envV, envC, envH, envT, envR); break; 
+            case ExpStmt s: ExpType(s.Expression, envV, envC, envH, envT, envR, envCPT); break; 
 
-            case Availability av: QueryIsWellTyped(av.Query, envV, envC, envH, envT, envR); break; // QueryIsWellTyped adds errors itself, no need to check in case as well
+            case Availability av: QueryIsWellTyped(av.Query, envV, envC, envH, envT, envR, envCPT); break; // QueryIsWellTyped adds errors itself, no need to check in case as well
             
             default: throw new Exception("Unknown statement."); // should never happen
         }
     }
 
     //Since un-bound variables throw exceptions, return value is not nullable. All other cases return types
-    private TypeT ExpType(Exp exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) =>
+    private TypeT ExpType(Exp exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) =>
         exp switch {
             BoolV     => new BoolT(),
             StringV   => new StringT(),
@@ -48,35 +49,35 @@ class TypeChecker {
             DateTimeV => new DateTimeT(),     
             DurationV => new DurationT(),
 
-            Reference r => HandleReference(r, envV, envH, envR), //cases: id || id.id
+            Reference r => HandleReference(r, envV, envH, envR, envCPT), //cases: id || id.id
 
-            Assignment a => HandleAssignment(a, envV, envC, envH, envT, envR),
+            Assignment a => HandleAssignment(a, envV, envC, envH, envT, envR, envCPT),
 
-            Reserve r => HandleReserve(r, envV, envC, envH, envT, envR ),
+            Reserve r => HandleReserve(r, envV, envC, envH, envT, envR, envCPT),
 
-            Reschedule r => HandleReschedule(r, envV, envC, envH, envT, envR),
+            Reschedule r => HandleReschedule(r, envV, envC, envH, envT, envR, envCPT),
 
-            BinaryOperation b => HandleBinary(b, envV, envC, envH, envT, envR),
+            BinaryOperation b => HandleBinary(b, envV, envC, envH, envT, envR, envCPT),
 
-            UnaryOperation u => HandleUnary(u, envV, envC, envH, envT, envR),
+            UnaryOperation u => HandleUnary(u, envV, envC, envH, envT, envR, envCPT),
 
 
             _ => throw new Exception($"Unknown {exp.LineNumber} expression.") // should never happen
         };
 
 /* ________________________Statement Handlers______________________________*/
-    private void HandleComposite(Composite cmp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        if(cmp.Stmt1 != null) StmtType(cmp.Stmt1, envV, envC, envH, envT, envR); // newScope ??
-        if(cmp.Stmt2 != null) StmtType(cmp.Stmt2, envV, envC, envH, envT, envR); // newScope ??
+    private void HandleComposite(Composite cmp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        if(cmp.Stmt1 != null) StmtType(cmp.Stmt1, envV, envC, envH, envT, envR, envCPT);
+        if(cmp.Stmt2 != null) StmtType(cmp.Stmt2, envV, envC, envH, envT, envR, envCPT); 
     }
 
-    private void HandleIf(If i, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TypeT type = ExpType(i.Condition, envV, envC, envH, envT, envR);
+    private void HandleIf(If i, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TypeT type = ExpType(i.Condition, envV, envC, envH, envT, envR, envCPT);
 
         if(type is not BoolT) errors.Add($"If statement expects condition of type 'bool' got '{type.ToString()}'");
 
-        if(i.ThenBody != null) StmtType(i.ThenBody, envV.NewScope(), envC, envH, envT, envR);        
-        if(i.ElseBody != null) StmtType(i.ElseBody, envV.NewScope(), envC, envH, envT, envR);
+        if(i.ThenBody != null) StmtType(i.ThenBody, envV.NewScope(), envC, envH, envT, envR, envCPT);        
+        if(i.ElseBody != null) StmtType(i.ElseBody, envV.NewScope(), envC, envH, envT, envR, envCPT);
     }
 
     private void HandleVarDecl(VarDecl decl, EnvV envV, EnvC envC) {
@@ -109,7 +110,7 @@ class TypeChecker {
         }
     }
 
-    private void HandleResourceDecl(ResourceDecl resDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private void HandleResourceDecl(ResourceDecl resDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         
         if(resDecl.Type is not ResourceT r) 
             errors.Add($"Expected type 'resource' got '{resDecl.Type}'");
@@ -126,7 +127,7 @@ class TypeChecker {
         foreach (Stmt stmt in resDecl.PropertyList) { // loop over fields
             switch (stmt) {
                 case VarDecl varDecl: { // Field decl without assignment
-                    HandleFieldDecl(resDecl, varDecl, envV, envR);
+                    HandlePropertyDecl(resDecl, varDecl, envV, envH, envR, envCPT, false);
                     break;
                 }
 
@@ -135,10 +136,10 @@ class TypeChecker {
                     Stmt2: ExpStmt exp      // guaranteed to be ExpStmt
                 }:  
 
-                    EnvV fieldScope = envV.NewScope();
-                    HandleFieldDecl(resDecl, varDecl, fieldScope, envR);
+                    EnvV propertyScope = envV.NewScope();
+                    HandlePropertyDecl(resDecl, varDecl, propertyScope, envH, envR, envCPT, true);
 
-                    TypeT expType = ExpType(exp.Expression, fieldScope, envC, envH, envT, envR);
+                    TypeT expType = ExpType(exp.Expression, propertyScope, envC, envH, envT, envR, envCPT);
                     if (varDecl.Type != expType) errors.Add($"Variable '{varDecl.Identifier}' expected type '{varDecl.Type}' got '{expType}'");
 
                     break;
@@ -146,20 +147,54 @@ class TypeChecker {
         }
     }
 
-    private void HandleFieldDecl(ResourceDecl resDecl, VarDecl varDecl, EnvV envV ,EnvR envR) {
+    private void HandlePropertyDecl(ResourceDecl resDecl, VarDecl varDecl, EnvV envV, EnvH envH, EnvR envR, EnvCPT envCPT, bool withAssignment) {
         if (varDecl.Type is ResourceT || varDecl.Type is ReservationT) {
             errors.Add($"'{varDecl.Type}' not allowed as field type for resource");
         } else {
+
             //A new scope is passed so within the resource envV is used as lookup, when assigning
-            envV.Bind(varDecl.Identifier, varDecl.Type);
+            if(withAssignment)
+            {
+                envV.Bind(varDecl.Identifier, varDecl.Type);  
+            }
 
             //For use outside resource
             envR.BindField(resDecl.Identifier, varDecl.Identifier, varDecl.Type);
+
+             //
+            CheckCategoryPropertyConflict(resDecl.Type, varDecl.Identifier, varDecl.Type, envH, envCPT);
+
         }
     }
 
+     private void CheckCategoryPropertyConflict(ResourceT resDeclType, string propertyId, TypeT incomingType, EnvH envH, EnvCPT envCPT) {
 
-    private void HandleTemplateDecl(TemplateDecl tmplDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+
+        foreach (ResourceT related in envH.GetAllRelated(resDeclType))
+        {
+            //Case 1: the property does not exist within current category
+            if (!envCPT.HasProperty(related.Category, propertyId))
+                 continue; //Skips rest of loop
+            
+            //Case 2: If this is reached. 2 The proper propertyId within category is of a different type than the declaration: Ok
+            TypeT existingType = envCPT.Lookup(related.Category, propertyId);
+
+            //2-fail: propertyId within category is of a different type than the declaration: Ok
+            if (existingType != incomingType) {
+                errors.Add(
+                    $"Conflicting types: property '{propertyId}' is declared as " +
+                    $"'{incomingType}' but already exists as '{existingType}' " +
+                    $"in category '{related.Category}'."
+                );
+            }
+                
+            return; // found in tree — consistent or error logged; do not bind again
+        }
+         //2.Success New to entire tree — register it
+        envCPT.Bind(resDeclType.Category, propertyId, incomingType);
+     }
+
+    private void HandleTemplateDecl(TemplateDecl tmplDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         if(tmplDecl.ParamList == null) return; // possible problems in template lookup due to null pointer dereference?
 
         EnvV tmplScope = envV.NewScope();
@@ -172,10 +207,10 @@ class TypeChecker {
         envT.Bind(tmplDecl.TemplateId, paramTypes); // bind template id to formal param types
 
         if(tmplDecl.TemplateBody != null) 
-            StmtType(tmplDecl.TemplateBody, tmplScope, envC, envH, envT, envR); // type check body. 
+            StmtType(tmplDecl.TemplateBody, tmplScope, envC, envH, envT, envR, envCPT); // type check body. 
     }
 
-    private void HandleTemplateCall(TemplateCall tc, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private void HandleTemplateCall(TemplateCall tc, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         List<TypeT> formalParamTypes = envT.Lookup(tc.TemplateId);
 
         if(formalParamTypes == null && tc.ArgList == null) return; // both lists are empty; illtyping is impossible
@@ -190,7 +225,7 @@ class TypeChecker {
 
         for (int i = 0; i < formalParamTypes.Count; i++) { // could loop over formal or actual parameter count: they are interchangable at this point
             TypeT expected = formalParamTypes[i];
-            TypeT actual = ExpType(tc.ArgList[i], envV, envC, envH, envT, envR);
+            TypeT actual = ExpType(tc.ArgList[i], envV, envC, envH, envT, envR, envCPT);
             
             if(actual is ResourceT a && expected is ResourceT e) { // if both are resources
                 if(!envH.IsSubtype(a, e)) // but not compatible types
@@ -204,24 +239,33 @@ class TypeChecker {
     }
 
 
-    private void HandleMove(Move move, EnvV envV, EnvC envC) {
+    private void HandleMove(Move move, EnvV envV, EnvC envC, EnvH envH ,EnvR envR, EnvCPT envCPT) {
 
         // Ensure id to move maps to a resource. V(r) = Resource. 
         TypeT type = envV.Lookup(move.ResourceId);
         if(type is ResourceT) {
 
             //Ensure id of category maps to a category
-            if(!envC.CategoryIsDeclared(move.CategoryId)) 
-                throw new Exception($"Use of undeclared category '{move.CategoryId}'.");
+            if(!envC.CategoryIsDeclared(move.Type.Category)) 
+                throw new Exception($"Use of undeclared category '{move.Type.Category}'.");
             
-            //
-            envV.ChangeCategory(move.ResourceId, new ResourceT(move.CategoryId));
+            //Before moving check for conflicts between the resource's property types and those of the category
+            Dictionary<string, TypeT> propertyTypeMap = envR.GetPropertyTypeMap(move.ResourceId);
+            
+            foreach(var property in propertyTypeMap ) {
+                
+                CheckCategoryPropertyConflict(move.Type, property.Key, property.Value, envH, envCPT);
+            }
+
+            //Currently moving wether or not conflicts occur
+            envV.ChangeCategory(move.ResourceId, new ResourceT(move.Type.Category));
+
         } else 
             errors.Add($"Expected type 'Resource' got '{type.ToString()}'");
     }
 
-    private void HandleCancel(Cancel cancel, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TypeT type = ExpType(cancel.Reservation, envV, envC, envH, envT, envR);
+    private void HandleCancel(Cancel cancel, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TypeT type = ExpType(cancel.Reservation, envV, envC, envH, envT, envR, envCPT);
         if(type is not ReservationT) errors.Add($"Expected type 'Reservation' got: {type.ToString()}.");
     }
 
@@ -229,24 +273,24 @@ class TypeChecker {
 
      /*________________________Query Well-Typedness. Availability and reserve_________________________________*/
   
-    private bool QueryIsWellTyped(QueryData queryData, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private bool QueryIsWellTyped(QueryData queryData, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         bool isWellTyped = true;
 
         EnvV reserveScope = envV.NewScope(); // Reservations allow for local declarations; create local scope
         
-        if(!ResourceSpecIsWellTyped(queryData.ResourceSpecs, reserveScope, envC, envH, envT, envR)) isWellTyped = false; // doesnt return given future errors still should be logged
+        if(!ResourceSpecIsWellTyped(queryData.ResourceSpecs, reserveScope, envC, envH, envT, envR, envCPT)) isWellTyped = false; // doesnt return given future errors still should be logged
 
-        if(!TimeSpecIsWellTyped(queryData.Interval, reserveScope, envC, envH, envT, envR))          isWellTyped = false; // doesnt return given future errors still should be logged
+        if(!TimeSpecIsWellTyped(queryData.Interval, reserveScope, envC, envH, envT, envR, envCPT))          isWellTyped = false; // doesnt return given future errors still should be logged
 
-        if(!ConditionIsWellTyped(queryData.Condition, reserveScope, envC, envH, envT, envR))        isWellTyped = false; // doesnt return given future errors still should be logged 
+        if(!ConditionIsWellTyped(queryData.Condition, reserveScope, envC, envH, envT, envR, envCPT))        isWellTyped = false; // doesnt return given future errors still should be logged 
 
-        if(!RecurrenceIsWellTyped(queryData.Recurrence, reserveScope, envC, envH, envT, envR))      isWellTyped = false; // doesnt return given future errors still should be logged
+        if(!RecurrenceIsWellTyped(queryData.Recurrence, reserveScope, envC, envH, envT, envR, envCPT))      isWellTyped = false; // doesnt return given future errors still should be logged
 
         return isWellTyped;
     }
 
     /// <summary> Check all resource specifications: a*rc ident | r </summary>
-    private bool ResourceSpecIsWellTyped(List<ResourceSpec> resourceSpecs, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private bool ResourceSpecIsWellTyped(List<ResourceSpec> resourceSpecs, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
       
         bool isWellTyped = true;
         
@@ -255,7 +299,7 @@ class TypeChecker {
             // "a rc" or "a rc id"
             if (resourceSpec.Quantity != null && resourceSpec.CategoryId != null) {
     
-                TypeT quantityType = ExpType(resourceSpec.Quantity, envV, envC, envH, envT, envR);
+                TypeT quantityType = ExpType(resourceSpec.Quantity, envV, envC, envH, envT, envR, envCPT);
 
                 if (quantityType is not NumberT) {
                     errors.Add($"Expected type 'Number' got '{quantityType}");
@@ -289,9 +333,9 @@ class TypeChecker {
 
         return isWellTyped;
     }
-    private bool TimeSpecIsWellTyped(TimeSpec timeSpec, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TypeT fromType = ExpType(timeSpec.Start, envV, envC, envH, envT, envR);
-        TypeT toType = ExpType(timeSpec.EndMarker, envV, envC, envH, envT, envR);
+    private bool TimeSpecIsWellTyped(TimeSpec timeSpec, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TypeT fromType = ExpType(timeSpec.Start, envV, envC, envH, envT, envR, envCPT );
+        TypeT toType = ExpType(timeSpec.EndMarker, envV, envC, envH, envT, envR, envCPT);
         
         return (fromType, toType) switch {
             (DateTimeT, DateTimeT) => true, // dt to dt
@@ -300,21 +344,21 @@ class TypeChecker {
         };
     }
 
-    private bool ConditionIsWellTyped(Exp? condition, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private bool ConditionIsWellTyped(Exp? condition, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         if(condition == null) return true; // cannot be illtyped if not present
 
-        TypeT condType = ExpType(condition, envV, envC, envH, envT, envR);
+        TypeT condType = ExpType(condition, envV, envC, envH, envT, envR, envCPT);
         return condType switch {
             BoolT => true,
             _  => Error($"Condition expected type 'bool' got '{condType.ToString()}'")
         };
     }
 
-    private bool RecurrenceIsWellTyped(RecurrenceSpec? recurrence, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private bool RecurrenceIsWellTyped(RecurrenceSpec? recurrence, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         if(recurrence == null) return true; // cannot be illtyped if not present
 
-        TypeT everyType = ExpType(recurrence.EveryDuration, envV, envC, envH, envT, envR);
-        TypeT endType = ExpType(recurrence.EndMarker, envV, envC, envH, envT, envR);
+        TypeT everyType = ExpType(recurrence.EveryDuration, envV, envC, envH, envT, envR, envCPT);
+        TypeT endType = ExpType(recurrence.EndMarker, envV, envC, envH, envT, envR, envCPT);
         return (everyType, endType) switch {
             (DurationT, DateTimeT) => true, // needs way to distinguish between for/until
             (DurationT, DurationT) => true,
@@ -326,16 +370,16 @@ class TypeChecker {
 
     /*_______________________Expression handlers__________________________________*/
 
-    private TypeT HandleReserve(Reserve reserveNode, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR ) {
+    private TypeT HandleReserve(Reserve reserveNode, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT ) {
         
         //Logs erros if any
-        QueryIsWellTyped(reserveNode.Query, envV, envC, envH, envT, envR);
+        QueryIsWellTyped(reserveNode.Query, envV, envC, envH, envT, envR, envCPT);
         
         //Best effort continued type-checking, should return a reservation wether or not query is well typed
         return new ReservationT();
     }
 
-    private TypeT HandleReference(Reference referenceNode, EnvV envV, EnvH envH, EnvR envR)
+    private TypeT HandleReference(Reference referenceNode, EnvV envV, EnvH envH, EnvR envR, EnvCPT envCPT)
     {
         //id case
         if (referenceNode.PropertyId == null) {
@@ -343,13 +387,13 @@ class TypeChecker {
         }
         //id.id case   
         else {
-            return HandlePropertyReference(referenceNode, envV, envH, envR);
+            return HandlePropertyReference(referenceNode, envV, envH, envR, envCPT);
         }        
     }
 
-    private TypeT HandlePropertyReference(Reference reference, EnvV envV, EnvH envH, EnvR envR) {
-        // Ensure that the variable is a resource type. Only these should allow property access.
-                
+    private TypeT HandlePropertyReference(Reference reference, EnvV envV, EnvH envH, EnvR envR, EnvCPT envCPT) {
+        
+        //Guard: Ensure that the variable is a resource type. Only these should allow property access.
         TypeT varType = envV.Lookup(reference.VariableId);
  
         if (varType is not ResourceT resource) {
@@ -359,47 +403,36 @@ class TypeChecker {
         // Case 1: Declared resources. Upon declaration, reglardless of having fields, a resource is registered to envR.
         if (envR.HasResource(reference.VariableId)) {
 
-            // id.id cases.'PropertyId' can never be null given case from which this method is invoked. Handles cases 
+            // id.id cases.'PropertyId' can never be null given case from which this method is invoked in HandleReference
             return envR.LookupField(reference.VariableId, reference.PropertyId);
         }
 
-        // Case 2: Does not exist in resource environment -> Bounded query variable. Find any resource of this category that has this field.
-        return LookupCategoryFieldType(resource, reference.PropertyId, envV, envH, envR);
+        // Case 2: Does not exist in resource environment -> Bounded query variable. Check envCPT categoryId x propertyId -> Type
+        return LookupCategoryPropertyType(resource, reference.PropertyId, envH, envCPT );
     }
-    
+
     /// <summary> Helper for property reference in bounded query variables within reserve or availability</summary>
-    private TypeT LookupCategoryFieldType(ResourceT type, string fieldName, EnvV envV, EnvH envH, EnvR envR) {
-
-        // Get all concrete resource IDs belonging to this category from EnvV
-        List<string> resourcesOfCategory = envV.GetResourcesByCategory(type, envV, envH);
+    private TypeT LookupCategoryPropertyType(ResourceT category, string propertyId, EnvH envH, EnvCPT envCPT) {
         
-        TypeT? resolvedType = null;
-
-        foreach (string resId in resourcesOfCategory) {
-            if (envR.HasResource(resId) && envR.HasField(resId, fieldName)) {
-                TypeT fieldType = envR.LookupField(resId, fieldName);
-                
-                // Catch type collisions (e.g., one DoubleRoom has int floor, another has string floor)
-                // SUBJECT FOR EVALUATION SUBJECT FOR EVALUATION SUBJECT FOR EVALUATION SUBJECT FOR EVALUATION SUBJECT FOR EVALUATION
-                if (resolvedType != null && resolvedType.GetType() != fieldType.GetType()) {
-                    errors.Add($"Type collision: Field '{fieldName}' in category '{type.Category}' has conflicting types.");
-                    return resolvedType; 
-                }
-                resolvedType = fieldType;
+        //Check all categories in subtree
+       foreach (ResourceT related in envH.GetSubtree(category)) {
+            
+            if (envCPT.HasProperty(related.Category, propertyId)) {
+                return envCPT.Lookup(related.Category, propertyId);
             }
         }
 
-        if (resolvedType != null) return resolvedType;
-
-        return new NumberT();
-
-    //error? new Exception($"No resource in category '{category}' contains the field '{fieldName}'.");
+        return Error(
+            $"No resource in the category tree of '{category.Category}' " +
+            $"declares a field '{propertyId}'.",
+            new BoolT()
+        );
     }
 
-     private TypeT HandleAssignment(Assignment assign, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TypeT varType = HandleReference(assign.Variable, envV, envH, envR);
+     private TypeT HandleAssignment(Assignment assign, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TypeT varType = HandleReference(assign.Variable, envV, envH, envR, envCPT);
 
-        TypeT expType = ExpType(assign.Value, envV, envC, envH, envT, envR);
+        TypeT expType = ExpType(assign.Value, envV, envC, envH, envT, envR, envCPT);
         
         if (varType is ResourceT) 
             errors.Add($"Assignment of expression to resource not allowed");
@@ -413,10 +446,10 @@ class TypeChecker {
         return varType; 
     }
 
-    private TypeT HandleReschedule(Reschedule r, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TimeSpecIsWellTyped(r.NewTimeInterval, envV, envC, envH, envT, envR); // Simply checks for errors in the [dt to dt / for dur]. Return value is discarded
+    private TypeT HandleReschedule(Reschedule r, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TimeSpecIsWellTyped(r.NewTimeInterval, envV, envC, envH, envT, envR, envCPT); // Simply checks for errors in the [dt to dt / for dur]. Return value is discarded
 
-        TypeT expType = ExpType(r.Reservation, envV, envC, envH, envT, envR);
+        TypeT expType = ExpType(r.Reservation, envV, envC, envH, envT, envR, envCPT);
         
         return expType switch {
             ReservationT => new ReservationT(),
@@ -424,10 +457,10 @@ class TypeChecker {
         };
     }
 
-    private TypeT HandleBinary(BinaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
+    private TypeT HandleBinary(BinaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         
-        TypeT left  = ExpType(exp.LeftExpression,  envV, envC, envH, envT, envR);
-        TypeT right = ExpType(exp.RightExpression, envV, envC, envH, envT, envR);
+        TypeT left  = ExpType(exp.LeftExpression,  envV, envC, envH, envT, envR, envCPT);
+        TypeT right = ExpType(exp.RightExpression, envV, envC, envH, envT, envR, envCPT);
         
         string operatorAsString = EnumToOp(exp.Operator);
         return exp.Operator switch
@@ -477,8 +510,8 @@ class TypeChecker {
         };
     }
 
-    private TypeT HandleUnary(UnaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR) {
-        TypeT operandType = ExpType(exp.Expression, envV, envC, envH, envT, envR);
+    private TypeT HandleUnary(UnaryOperation exp, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+        TypeT operandType = ExpType(exp.Expression, envV, envC, envH, envT, envR, envCPT);
         string operatorAsString = EnumToOp(exp.Operator);
         return exp.Operator switch {
             UnaryOperator.NOT when (operandType is BoolT) => new BoolT(),


### PR DESCRIPTION
## Hvad gør denne PR?
- Fixed error in parsing durations. (Subject to slight refactor)
- Errors consistently in typechecking, exceptions only in internal logic
- All properties within a given hierarchy with same id constricted to same type. (Per Giovanni)
  - To statically typecheck local variable bindings in queries and alleviate interpretor from all illtyping


## Hvorfor?
Help testing type-checking
