### PR TITLE
duration ordering fix, template args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ desktop.ini
 *.tmp
 *.temp
 src/RAL/testing.ral
+src/RAL/test.ral

--- a/CocoR/ralGrammar.cs.atg
+++ b/CocoR/ralGrammar.cs.atg
@@ -241,10 +241,10 @@ PRODUCTIONS
   .
 
   TemplateDecl<out Stmt stmt> = 
-    "template"                  (. int lineNumber = t.line; List<VarDecl>? paramList = null; .)
+    "template"                  (. int lineNumber = t.line; List<VarDecl> paramList = new(); .)
     ident                       (. string templateId = t.val; .)
     "(" 
-    [                              (. paramList = new List<VarDecl>(); .)
+    [                              
       Param<out VarDecl param>     (. paramList.Add(param);.)
       { ","                    
         Param<out VarDecl nextParam> (. paramList.Add(nextParam); .)
@@ -356,9 +356,9 @@ PRODUCTIONS
   /* Template invocation, argList is null unless arguments have been provided */
   TemplateCall<out Stmt stmt> =
     "use"                     (. int lineNumber = t.line; .)
-    ident                     (. string templateId = t.val; List<Exp>? argList = null; .)
+    ident                     (. string templateId = t.val; List<Exp> argList = new(); .)
     "("
-    [                         (. argList = new List<Exp>(); .)
+    [                         
       Exp<out Exp arg>        (. argList.Add(arg);.)
       { "," 
         Exp<out Exp nextArg>  (. argList.Add(nextArg);.)
@@ -449,100 +449,40 @@ PRODUCTIONS
     .
 
   /*alternative that does not enforce unit structure/repetition = number Unit {number Unit} */
-  /* number, not expression. Would give lookahead problem otherwise 
-  DurationRefactored<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
+  /* number, not expression. Would give lookahead problem otherwise */
+  Duration<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
     
-      (
+    (
       IF(FollowedByWeek()) number (. days = int.Parse(t.val) * 7; .) ("w" | "week" | "weeks")
       [ 
-        number (. days += int.Parse(t.val); .) ("d" | "day" | "days") 
+        IF(FollowedByDay()) number (. days += int.Parse(t.val); .) ("d" | "day" | "days") 
       ]
       [ 
-        number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
+        IF(FollowedByHour()) number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
       ]
       [ 
         number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes") 
       ]
 
-    | IF(FollowedByDay())
-      number (. days = int.Parse(t.val); .) ("d" | "day" | "days")
+    | 
+      IF(FollowedByDay()) number (. days = int.Parse(t.val); .) ("d" | "day" | "days")
       [ 
-        number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
+       IF(FollowedByHour()) number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") 
       ]
       [ 
-        number (. minutes = int.Parse(t.val); .) 
-      ("m" | "minute" | "minutes") ]
+        number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes") 
+      ]
 
-    | IF(FollowedByHour())
-      number (. hours = int.Parse(t.val); .)
-      ("h" | "hour" | "hours")
-      [ number (. minutes = int.Parse(t.val); .) 
-      ("m" | "minute" | "minutes") ]
+    | 
+      IF(FollowedByHour()) number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours")
+      [ number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes") ]
 
-    | number (. minutes = int.Parse(t.val); .)
-      ("m" | "minute" | "minutes")
+    | 
+      number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes")
     )
 
     (. exp = new DurationV(t.line, new TimeSpan(days, hours, minutes, 0)); .)
-  .*/
-
-/** to use
-  Duration<out Exp exp> (. exp = null; int days = 0, hours = 0, minutes = 0; .) =
-    
-    Weeks | Days | Hours | Minutes 
-      
-      (. exp = new DurationV(t.line, new TimeSpan(days, hours, minutes, 0)); .)
-    .
-
-  Weeks<out int days> =
-    IF(FollowedByWeek()) number (. days = int.Parse(t.val) * 7; .) ("w" | "week" | "weeks") [Days]
   .
-
-  Days<out int days> = 
-    IF(FollowedByDay()) number (. days = int.Parse(t.val); .) ("d" | "day" | "days") [Hours]
-  .
-
-  Hours<out int hours> = 
-    IF(FollowedByHour())  number (. hours = int.Parse(t.val); .) ("h" | "hour" | "hours") [Minutes]
-  .
-
-  Minutes<out int minutes> =
-     number (. minutes = int.Parse(t.val); .) ("m" | "minute" | "minutes")
-  .
-*/
-  Duration<out Exp exp> (. exp = null; int weeks = 0, days = 0, hours = 0, minutes = 0; .)
-    =
-    ((
-      IF(FollowedByWeek())
-      number                        (. weeks = int.Parse(t.val); .)
-      ("w" | "week" | "weeks")
-
-    | IF(FollowedByDay())
-      number                        (. days = int.Parse(t.val); .)
-      ("d" | "day" | "days")
-
-    | IF(FollowedByHour())
-      number                        (. hours = int.Parse(t.val); .)
-      ("h" | "hour" | "hours")
-
-    | number                        (. minutes = int.Parse(t.val); .)
-      ("m" | "minute" | "minutes")
-    )
-
-    [ IF(FollowedByDay())
-      number                        (. days = int.Parse(t.val); .)
-      ("d" | "day" | "days") ]
-
-    [ IF(FollowedByHour())
-      number                        (. hours = int.Parse(t.val); .)
-      ("h" | "hour" | "hours") ]
-
-    [ 
-      number                        (. minutes = int.Parse(t.val); .)
-      ("m" | "minute" | "minutes") ]
-    )
-    (. exp = new DurationV(t.line, new TimeSpan(days + weeks * 7, hours, minutes, 0)); .)
-    .
 
                    
   Recurrence<out RecurrenceSpec recurrence> = //assigning default to bypass unassigned local variable error in parser  

--- a/src/RAL/AST/Stmt.cs
+++ b/src/RAL/AST/Stmt.cs
@@ -18,7 +18,7 @@ record class ResourceDecl(int LineNumber, ResourceT Type, string Identifier, Lis
 
 record class CategoryDecl (int LineNumber, string CategoryId, string? ParentId) : Stmt(LineNumber);
 
-record class TemplateDecl(int LineNumber, string TemplateId, List<VarDecl>? ParamList, Stmt? TemplateBody) : Stmt(LineNumber);
+record class TemplateDecl(int LineNumber, string TemplateId, List<VarDecl> ParamList, Stmt? TemplateBody) : Stmt(LineNumber);
 
 record class Move(int LineNumber, string ResourceId, ResourceT Type ) : Stmt(LineNumber);
 
@@ -31,6 +31,6 @@ record class ExpStmt(int LineNumber, Exp Expression) : Stmt(LineNumber);
 
 record class Availability(int LineNumber, QueryData Query) : Stmt(LineNumber);
 
-record class TemplateCall(int LineNumber, string TemplateId, List<Exp>? ArgList) : Stmt(LineNumber);
+record class TemplateCall(int LineNumber, string TemplateId, List<Exp> ArgList) : Stmt(LineNumber);
 
 record class Skip(int LineNumber) : Stmt(LineNumber);

--- a/src/RAL/AST/Type.cs
+++ b/src/RAL/AST/Type.cs
@@ -3,21 +3,21 @@ namespace RAL.AST;
 ///<summary> Singletons not needed, as record types have value equality: Two objects are equal if they're of the same type & storing same values. </summary>
 public abstract record TypeT { }
 
-public sealed record BoolT : TypeT { public override string ToString() { return "bool"; }}
+public sealed record BoolT : TypeT { public override string ToString() { return "Bool"; }}
 
-public sealed record NumberT : TypeT { public override string ToString() { return "number"; }}
+public sealed record NumberT : TypeT { public override string ToString() { return "Number"; }}
 
-public sealed record StringT : TypeT { public override string ToString() { return "string"; }}
+public sealed record StringT : TypeT { public override string ToString() { return "String"; }}
 
-/// <summary> Conveys user-defined resource types and pre-defined root "Resource" type, which has Category = "". </summary>
+/// <summary> Conveys user-defined resource types and pre-defined root "Resource" type, which has Category = "Resource". </summary>
 public sealed record ResourceT(string Category) : TypeT { public override string ToString() { return this.Category; }} // holds the specific category
 
-public sealed record ReservationT : TypeT { public override string ToString() { return "reservation"; }}
+public sealed record ReservationT : TypeT { public override string ToString() { return "Reservation"; }}
 
-public sealed record DurationT : TypeT { public override string ToString() { return "duration"; }}
+public sealed record DurationT : TypeT { public override string ToString() { return "Duration"; }}
 
 public sealed record DateTimeT : TypeT { public override string ToString() { return "Datetime"; }}
 
 public sealed record ErrorT(string Msg) : TypeT { public override string ToString() { return this.Msg; }};
 
-public sealed record CategoryT : TypeT { public override string ToString() { return "category"; }} // delete?
+public sealed record CategoryT : TypeT { public override string ToString() { return "Category"; }} // delete?

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata;
 using RAL.AST;
 
 namespace RAL.Interpreter;
@@ -214,7 +213,7 @@ public class Interpreter {
 
             // Reserve and seq
 
-            _ => throw new Exception($"Line {exp.LineNumber}: Invalid binary operation.")
+            _ => throw new Exception($"Line {exp.LineNumber}: Invalid binary operation.") // Should never happen
         };
     }
 
@@ -230,7 +229,7 @@ public class Interpreter {
             UnaryOperator.NEG when value is NumberVal n
                 => new NumberVal(-n.Value),
 
-            _ => throw new Exception($"Line {exp.LineNumber}: Invalid unary operation.")
+            _ => throw new Exception($"Line {exp.LineNumber}: Invalid unary operation.") // Should never happen
         };
     }
 

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -205,7 +205,6 @@ class TypeChecker {
      }
 
     private void HandleTemplateDecl(TemplateDecl tmplDecl, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
-        if(tmplDecl.ParamList == null) return;
 
         EnvV tmplScope = envV.NewScope();
         List<TypeT> paramTypes = new();
@@ -222,18 +221,13 @@ class TypeChecker {
     }
 
     private void HandleTemplateCall(TemplateCall tc, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
-        List<TypeT>? formalParamTypes = envT.Lookup(tc.TemplateId);
+        List<TypeT> formalParamTypes = envT.Lookup(tc.TemplateId);
 
-        if(formalParamTypes == null && tc.ArgList == null) return; // both lists are empty; illtyping is impossible
-
-        if(formalParamTypes != null && tc.ArgList == null || 
-           formalParamTypes == null && tc.ArgList != null ||
-           formalParamTypes.Count != tc.ArgList.Count) { // XOR?
-            errors.Add($"{tc.TemplateId} expected {(formalParamTypes == null ? "0" : formalParamTypes.Count)}" +
-                                        $"arguments got {(tc.ArgList == null ? "0" : tc.ArgList.Count)}");
-            return; // return to avoid null dereference exceptions
+        if(formalParamTypes.Count != tc.ArgList.Count) {
+            errors.Add($"{tc.TemplateId} expected {formalParamTypes.Count} argument(s) got {tc.ArgList.Count}");
         }
 
+        if(formalParamTypes.Count == 0 || tc.ArgList.Count == 0) return;
         for (int i = 0; i < formalParamTypes.Count; i++) { // could loop over formal or actual parameter count: they are interchangable at this point
             TypeT expected = formalParamTypes[i];
             TypeT actual = ExpType(tc.ArgList[i], envV, envC, envH, envT, envR, envCPT);
@@ -303,7 +297,7 @@ class TypeChecker {
         return isWellTyped;
     }
 
-    /// <summary> Check all resource specifications: a*rc ident | r </summary>
+    /// <summary> Check all resource specifications: a rc ident | r </summary>
     private bool ResourceSpecIsWellTyped(List<ResourceSpec> resourceSpecs, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
       
         bool isWellTyped = true;

--- a/tests/RAL.Tests/AstTraversalTests.cs
+++ b/tests/RAL.Tests/AstTraversalTests.cs
@@ -279,7 +279,7 @@ public class AstTraversalTests
         var c3 = Assert.IsType<Composite>(c2.Stmt2);
         var move = Assert.IsType<Move>(c3.Stmt2);
         Assert.Equal("myRoom", move.ResourceId);
-        Assert.Equal("Suite",  move.CategoryId);
+        Assert.Equal(new ResourceT("Suite"),  move.Type);
     }
 
     [Fact]

--- a/tests/RAL.Tests/TestHelpers.cs
+++ b/tests/RAL.Tests/TestHelpers.cs
@@ -97,7 +97,7 @@ static class TestHelpers
     public static TypeChecker RunTypeChecker(Stmt node)
     {
         var tc = new TypeChecker();
-        tc.StmtType(node, new EnvV(), new EnvC(), new EnvH(), new EnvT(), new EnvR());
+        tc.StmtType(node, new EnvV(), new EnvC(), new EnvH(), new EnvT(), new EnvR(), new EnvCPT());
         return tc;
     }
 


### PR DESCRIPTION
- Typechecking of templates with empty formel/actual paramlist 
- Adjusts test compiler errors after changes in nodes. 
- duration literal ordering enforced. 
