### PR TITLE
Interpreter functionally complete

### DIFF
--- a/CocoR/ralGrammar.cs.atg
+++ b/CocoR/ralGrammar.cs.atg
@@ -413,14 +413,16 @@ PRODUCTIONS
   // a*rc id (qty of category with local variable binding for constraints) | r.
    ResourceExp<. out List<ResourceSpec> resources .> = (. resources = new List<ResourceSpec>(); Exp? quantity = null; string? categoryId = null; string? identifier = null; .)   
     ( 
-      IF(FollowedByAND_or_FROM()) ident /* r  */ (. identifier = t.val; .)
+      IF(FollowedByAND_or_FROM()) ident /* r  */ (. resources.Add(new ResourceInstanceSpec(t.val)); .)
       |
       AdditiveExp<out Exp exp>          /* a  */ (. quantity = exp; .)     //At interpretaion, only makes sense for natural numbers
       ident                             /* rc */ (. categoryId = t.val; .)
       [
-        ident            /* local var binding */ (. identifier = t.val; .)
+        ident            /* local var binding */ (. identifier = t.val; resources.Add(new CategorySpecWithBinding(quantity, categoryId, identifier)); .)
       ]
-    )       (. resources.Add(new ResourceSpec(quantity, categoryId, identifier)); .)            
+      //No local var binding, identifier was set to null on nonterminal entry meaning the above case did not happen    
+      (. if (identifier == null) { resources.Add(new CategorySpec(quantity, categoryId)); }.)
+    )                   
     { "and"   /* Re and Re:   composite without left recursion */
       ResourceExp <. out List<ResourceSpec> continuation .>   (. resources.AddRange(continuation);.)
     }    
@@ -430,13 +432,13 @@ PRODUCTIONS
 /*__________________________________________TIME__________________________________________*/
 
 /*                              Typecheck requires*/
-  Time<out TimeSpec timeInterval>  =              (. Exp? endMarker = null;  .)   
-    "from" Exp<out Exp startDateTime> /*DateTime*/ 
+  Time<out TimeSpec timeInterval>  =                      //To bypass needing initialization before control leaves
+    "from" Exp<out Exp startDateTime> /*DateTime*/        (. timeInterval = new TimeSpecTo(startDateTime, startDateTime);.)
     ( 
-    "to" AdditiveExp<out Exp toDatetime> /*DateTime*/     (. endMarker = toDatetime; .) //jump over nonterminals with logical operators, to avoid ambiguity exp and exp
+    "to" AdditiveExp<out Exp toDatetime> /*DateTime*/     (. timeInterval = new TimeSpecTo(startDateTime, toDatetime);.) //jump over nonterminals with logical operators, to avoid ambiguity exp and exp
     | 
-    "for" AdditiveExp<out Exp forDuration> /*Duration*/   (. endMarker = forDuration; .)
-    )                                             (. timeInterval = new TimeSpec(startDateTime, endMarker); .)
+    "for" AdditiveExp<out Exp forDuration> /*Duration*/   (. timeInterval = new TimeSpecFor(startDateTime, forDuration);   .)
+    )
   .
 
   Datetime<out Exp exp> = (. string dateTimeToParse = null; .) 
@@ -485,16 +487,16 @@ PRODUCTIONS
 
                    
   Recurrence<out RecurrenceSpec recurrence> = //assigning default to bypass unassigned local variable error in parser  
-    "recurring"                       (. RecurrenceMode mode = RecurrenceMode.STRICT; Exp? endMarker = null; .)
+    "recurring"                       (. RecurrenceMode mode = RecurrenceMode.STRICT; RecurrenceInterval? interval = null; .)
     ( 
       "strict"                        (. mode = RecurrenceMode.STRICT; .)
       | 
       "flexible"                      (. mode = RecurrenceMode.FLEXIBLE; .)
     )             
     "every" Exp<out Exp everyDuration>     
-    ( "until" AdditiveExp<out Exp toDatetime> (. endMarker = toDatetime; .) //jump over logical operator nonterminals to avoid ambiguity between exp and exp
-    | "for" AdditiveExp<out Exp forDuration>  (. endMarker = forDuration; .)
-    )                                 (. recurrence = new RecurrenceSpec(mode, everyDuration, endMarker); .)
+    ( "until" AdditiveExp<out Exp toDatetime> (. interval = new RecurrenceUntil(everyDuration, toDatetime); .) //jump over logical operator nonterminals to avoid ambiguity between exp and exp
+    | "for" AdditiveExp<out Exp forDuration>  (. interval = new RecurrenceFor(everyDuration, forDuration); .)
+    )                                         (. recurrence = new RecurrenceSpec(mode, interval); .)
   .
 
 END RAL.

--- a/src/RAL/AST/QueryData.cs
+++ b/src/RAL/AST/QueryData.cs
@@ -8,28 +8,50 @@ record class QueryData(
     Exp? Condition,                   //where clause / predicate
     RecurrenceSpec? Recurrence         //recurence information
 );
+/*________________________RESOURCES________________________*/
+/// <summary> Super for data for a single resource specification: a*rc [id] | r. </summary>
+abstract record class ResourceSpec;
 
-/// <summary> Holds data for a single resource specification: a*rc id | r. </summary>
-record class ResourceSpec(
-    Exp? Quantity,      // a
-    string? CategoryId, // rc
-    string? Identifier  // id for declaring local variable (nullable) | id of single named resource r 
-);
+/// <summary> id of single named resource </summary>
+record class ResourceInstanceSpec(
+    string ResourceId
+) : ResourceSpec;
 
-/// <summary> Data structure for time interval of query. 
-/// Classes may be further divided for exhaustiveness checking. </summary>
-record class TimeSpec(
+/// <summary> a rc. Quantity of a category (or subtypes). </summary>
+record class CategorySpec(
+    Exp Quantity,           // a
+    string CategoryId       // rc
+) : ResourceSpec;
+
+/// <summary> a rc id. Quantity of a category (or subtypes) with local variable binding. </summary>
+record class CategorySpecWithBinding(
+    Exp Quantity,           // a
+    string CategoryId,      // rc
+    string LocalBindingId   // id
+) : CategorySpec(Quantity, CategoryId);
+
+
+/*________________________TIME________________________*/
+/// <summary> Data structure for time interval of query.
+abstract record class TimeSpec(
     Exp Start,     // DateTime
     Exp EndMarker // "to" DateTime | "For" Duration
 );
+record class TimeSpecTo(Exp Start, Exp To): TimeSpec(Start, To);
+record class TimeSpecFor(Exp Start, Exp For): TimeSpec(Start, For);
 
-/// <summary>
-/// Data structure for reccurrence information
-/// </summary>
-record class RecurrenceSpec(
-    RecurrenceMode Mode, //STRICT | FLEXIBLE
-    Exp EveryDuration,        //"every" Duration. Defines interval between reservations
-    Exp EndMarker        // "until" DateTime | "for" Duration
-);
+
+/*________________________RECURRENCE________________________*/
+/// <summary> Data structure for reccurrence information </summary>
+record class RecurrenceSpec(RecurrenceMode Mode, RecurrenceInterval Time);
 
 enum RecurrenceMode { STRICT, FLEXIBLE }
+
+/// <summary> Defines interval between reservations until end. Recurrance interval hierarchy super. "every" Duration, ("until" DateTime | "for" Duration) </summary>
+abstract record class RecurrenceInterval(Exp Every, Exp EndMarker);
+
+///(Duration, DateTime)
+record class RecurrenceUntil(Exp Every, Exp Until ): RecurrenceInterval(Every, Until);
+
+/// (Duration, Duration)
+record class RecurrenceFor(Exp Every, Exp For ): RecurrenceInterval(Every, For);

--- a/src/RAL/Interpreter/EnvH.cs
+++ b/src/RAL/Interpreter/EnvH.cs
@@ -5,7 +5,6 @@ public class EnvH()
         {"Resource", null} 
     }; 
 
-
     /// <summary>  </summary>
     /// <param name="categoryId"> The newly declared category. </param>
     /// <param name="parentId"> If null supplied, "Resource" is parent </param>
@@ -13,4 +12,31 @@ public class EnvH()
     {
         parentCatRelations.Add(categoryId, parentId ?? "Resource");
     }
+
+    /// <summary> flat enumarable of subCategories (including itself), organised by descendant level </summary>
+    public IEnumerable<string> GetSubCategories(string categoryId) {
+        
+        HashSet<string> subCategories  = [];
+        
+        //breadth first, i.e. organised by nearest descendants
+        var queue = new Queue<string>();
+        queue.Enqueue(categoryId);
+
+        while (queue.Count > 0) {
+            string current = queue.Dequeue();
+            subCategories.Add(current);
+
+            foreach (string child in GetChildren(current))
+                queue.Enqueue(child);
+        }
+
+        return subCategories;
+    }
+
+    /// <summary> Find all categories whose immediate parent is 'current' </summary>
+    private IEnumerable<string> GetChildren(string categoryId) =>  
+        parentCatRelations
+            .Where(relation => relation.Value == categoryId)
+            .Select(relation => relation.Key);
+
 }

--- a/src/RAL/Interpreter/EnvTem.cs
+++ b/src/RAL/Interpreter/EnvTem.cs
@@ -1,9 +1,11 @@
 using RAL.AST;
-
 namespace RAL.Interpreter;
 
+/// <summary> Template Environment, supporting lookup and bind of a symbol, i.e. templateId, -> encapsulation of param names & body. 
+/// Return values not supported. </summary>
 public class EnvTem {
 
+    //Datastructure "template table"
     private readonly Dictionary<string, tAttribute > tTable = new();
 
     public void Bind(string templateId, List<string> parameterNames, Stmt body) {
@@ -11,12 +13,9 @@ public class EnvTem {
         tTable.Add(templateId, new tAttribute(parameterNames, body));        
     }
 
-    //Lookup
-
     internal tAttribute Lookup(string templateId) {
         return tTable[templateId];        
     }
-
 }
 
 internal record class tAttribute(

--- a/src/RAL/Interpreter/EnvTem.cs
+++ b/src/RAL/Interpreter/EnvTem.cs
@@ -1,0 +1,25 @@
+using RAL.AST;
+
+namespace RAL.Interpreter;
+
+public class EnvTem {
+
+    private readonly Dictionary<string, tAttribute > tTable = new();
+
+    public void Bind(string templateId, List<string> parameterNames, Stmt body) {
+
+        tTable.Add(templateId, new tAttribute(parameterNames, body));        
+    }
+
+    //Lookup
+
+    internal tAttribute Lookup(string templateId) {
+        return tTable[templateId];        
+    }
+
+}
+
+internal record class tAttribute(
+        List<string> ParameterNames,
+        Stmt Body
+    );

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -238,54 +238,69 @@ public class Interpreter {
         return value;
     }
 
+/// <summary> Evaluates reserve leaf nodes, covering two cases. 1: simple, 2: with recurring </summary>
     private static ReservationVal EvalReserve(Reserve reserveNode, EnvV envV, EnvH envH) {
-        (int lineNumber, QueryData query) = reserveNode;
+        QueryData originalQuery = reserveNode.Query;        
 
-        /* List of ResourceSpec, elements guarenteed by subclassing
-         - a * CategoryId id    (quantity of a category (or subtypes) + local var binding)      (CategorySpecWithBinding)
-         - a * CategoryId       (quantity of a category(or subtypes)  - no local var binding)   (CategorySpec)
-         - ResourceId           (previously declared resource)                                  (ResourceInstanceSpec)
-        */
+        //Extract reservation time period for the base query
+        (DateTime originalStart, DateTime originalEnd, TimeSpan duration) = ComputeTime(originalQuery.Interval, envV, envH);
+
+        //Treat all queries equally. Wether an AST without recurring or simulated for requrrence         
+        ResolvedQuery baseQuery = new ResolvedQuery(originalQuery.ResourceSpecs, originalStart, originalEnd, originalQuery.Condition);
+
+        ReservationVal result = ExecuteSingleReservation(baseQuery, envV, envH); 
+
+        //Case 1: Simple reserve node, no recurring
+        if (originalQuery.Recurrence == null) {
+            return result;
+        } 
         
-
-        //Extract timespec 
-        (DateTime start, DateTime end) = ComputeTimePeriod(query.Interval, envV, envH);
+        //Case 2: reserve node with recurring -> simmulate making queryData objects of nodes. Resolved queries shows purpose here.
         
+        List<ResolvedQuery> timeSlots = new() { baseQuery };
+        (TimeSpan timeBetween, DateTime recurrenceEnd) = ComputeRecurrencePeriod(originalQuery.Recurrence.Time, originalStart, envV, envH);
+        
+        //Accumulate each simple reservation request, starting from the second reservation occurrence.
+        for (DateTime slotStart = originalStart + timeBetween; slotStart < recurrenceEnd; slotStart += timeBetween) {
 
-
-        if (query.Recurrence != null){
-            (TimeSpan intervalBetween, DateTime recurrenceEnd) = ComputeRecurrencePeriod(query.Recurrence.Time, start, envV, envH);
-            
-            for (DateTime currentStart = start + intervalBetween; currentStart < recurrenceEnd; currentStart += intervalBetween) {
-
-                switch (query.Recurrence.Mode)
-                {
-                case RecurrenceMode.FLEXIBLE: //EvalReserveSEQ, with the queryData without the recurrence, start and end times for this itteration
-                        break;
-
-                    case RecurrenceMode.STRICT: //EvalReserveAND, , with the queryData without the recurrence, start and end times for this itteration
-                        break;
-                    
-                };
-                
-            }
+            timeSlots.Add(baseQuery with {Start = slotStart, End = slotStart + duration}); 
         }
 
-        //for compiler currently
-        return new ReservationVal(new List<ReservationAtomVal>());
+        foreach (ResolvedQuery slot in timeSlots.Skip(1)) {
+            result = originalQuery.Recurrence.Mode switch {
+                RecurrenceMode.STRICT => EvalReserveAND(result, () => ExecuteSingleReservation(slot, envV, envH)),
+                RecurrenceMode.FLEXIBLE => EvalReserveSEQ(result, () => ExecuteSingleReservation(slot, envV, envH)),
+                _ => throw new Exception("Unknown recurrence mode")
+            };
+        }
+        return result;
+    }
+
+     private static ReservationVal ExecuteSingleReservation(ResolvedQuery query, EnvV envV, EnvH envH) {
+        /*var validCombination = FindAvailableResources(query, envV, envH);
+        
+        if (validCombination.Any()) {
+            // Commit to registry
+            ReservationVal newReservation = new ReservationVal(validCombination);
+            ReservationRegistry.Instance().AddReservation(newReservation);
+            return newReservation;
+        }
+        */
+        
+        return new ReservationVal(new List<ReservationAtomVal>()); // Failed
     }
 
     /// <summary> Returns a tupple of start DateTime and end DateTime in unwrapped, c# types </summary>
-    private static (DateTime, DateTime) ComputeTimePeriod(TimeSpec timeSpec, EnvV envV, EnvH envH){
+    private static (DateTime, DateTime, TimeSpan) ComputeTime(TimeSpec timeSpec, EnvV envV, EnvH envH){
 
         //Evaluate the expressions within timespec
         Value startVal = EvalExp(timeSpec.Start, envV, envH);
         Value endMarkerVal = EvalExp(timeSpec.EndMarker, envV, envH);
 
         //Return unwrapped c#
-        return (startVal, endMarkerVal) switch {
-            (DateTimeVal start, DateTimeVal to) => (start.Value, to.Value),
-            (DateTimeVal start, DurationVal For) =>(start.Value, start.Value + For.Value),
+        return (startVal, endMarkerVal) switch {   //start dt  ,    end dt   , duration of reservation
+            (DateTimeVal start, DateTimeVal to) => (start.Value, to.Value,  to.Value - start.Value),
+            (DateTimeVal start, DurationVal For) =>(start.Value, start.Value + For.Value, For.Value),
             _ => throw new Exception("Invalid time specification.\n") 
         };
 
@@ -309,16 +324,16 @@ public class Interpreter {
         };
     }
 
-    //Right operand Exp rightExp is intentionally not evaluated here. 
+    /// <summary> Regular path: Coming from a binary operation node. Right operand Exp rightExp is intentionally not evaluated here. </summary>
     private static ReservationVal EvalBinaryReserve(BinaryOperator op, ReservationVal leftReservation, Exp rightExp, EnvV envV, EnvH envH ) {
 
         return op switch {
 
             BinaryOperator.OR => EvalReserveOR(leftReservation, rightExp, envV, envH),
 
-            BinaryOperator.AND => EvalReserveAND(leftReservation, rightExp, envV, envH),
+            BinaryOperator.AND => EvalReserveAND(leftReservation, () => (ReservationVal) EvalExp(rightExp, envV, envH)),
 
-            BinaryOperator.SEQ => EvalReserveSEQ(leftReservation, rightExp, envV, envH),
+            BinaryOperator.SEQ => EvalReserveSEQ(leftReservation, () => (ReservationVal) EvalExp(rightExp, envV, envH)),
 
             _ => throw new Exception("Unexpected operator in reservation binary")
             
@@ -335,33 +350,48 @@ public class Interpreter {
 
         else //left reserve attempt did not fail, return it without having attempted reserving right
             return leftReservation; 
-        
     }
 
-    private static ReservationVal EvalReserveAND(ReservationVal leftReservation, Exp rightExp, EnvV envV, EnvH envH ) {
+    /// <summary> Both must succeed. Rolls back left if right fails. 
+    /// Two paths lead here: 1. Binary AND operation, 2. STRICT reccurrence evaluation from a leaf. </summary>
+    private static ReservationVal EvalReserveAND(ReservationVal leftReservation, Func<ReservationVal> evaluateRight ) {
 
         //Case 1: left failed, don't attempt right. No reservations to delete. The empty list in left indicates a failure.
         if (leftReservation.Failed()) 
             return leftReservation;
 
-        //
-        ReservationVal rightReservation = (ReservationVal) EvalExp(rightExp, envV, envH);
+        //Left didnt fail, evaluate right with the passed function from parameter.
+        ReservationVal rightReservation = evaluateRight();
 
         //Case 2: left succeded, right failed.
         if (rightReservation.Failed()) {
 
-            // Delete all reservatiosn in left. 
+            // Delete all reservations in left. 
+            leftReservation.Reservations.Clear();
+
+            //Remove from register
+            
+            //return a reservationVal with an empty list -> indicates failed reservation attempt
+            return leftReservation;
         }
 
         //Case 3: both succeded
         else {
+            //Combine reservations to a composite, in the original
+            leftReservation.Reservations.AddRange(rightReservation.Reservations);
 
-            //Concatenate the reservationList
-        }      
-        return leftReservation;//stub for compiler errors  
+            //return the reservation which is now interpreted as a composite
+            return leftReservation;
+        }
     }
 
-    private static  ReservationVal EvalReserveSEQ(ReservationVal leftReservation, Exp rightExp, EnvV envV, EnvH envH ) {
+    /// <summary> Two paths lead here: 1. Binary reserve operation, 2. FLEXIBLE reccurrence evaluation from a leaf. </summary>
+    private static  ReservationVal EvalReserveSEQ(ReservationVal leftReservation, Func<ReservationVal> evaluateRight ) {
+        ReservationVal rightReservation = evaluateRight();
+
+        //Combine reservations to a composite, in the original - wether either were empty
+        leftReservation.Reservations.AddRange(rightReservation.Reservations);
+        
         return leftReservation;//stub for compiler errors  
     }
 

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -61,7 +61,7 @@ public class Interpreter {
 
             Reference r => EvalReference(r, envV),
             
-            Reserve reserveNode => EvalReserve(reserveNode.Query),
+            Reserve reserveNode => EvalReserve(reserveNode, envV, envH),
             // reschedule join
 
             Assignment a => EvalAssignment(a, envV, envH),
@@ -238,28 +238,76 @@ public class Interpreter {
         return value;
     }
 
-    private static ReservationVal EvalReserve(QueryData query) {
+    private static ReservationVal EvalReserve(Reserve reserveNode, EnvV envV, EnvH envH) {
+        (int lineNumber, QueryData query) = reserveNode;
 
-        /* Resource spec contains a list of objects guarenteed by grammar to be 
-         - a * CategoryId id    (quantity of a category (or subtypes) + local var binding)
-         - a * CategoryId       (quantity of a category(or subtypes)  - no local var binding)
-         - ResourceId           (previously declared resource)
+        /* List of ResourceSpec, elements guarenteed by subclassing
+         - a * CategoryId id    (quantity of a category (or subtypes) + local var binding)      (CategorySpecWithBinding)
+         - a * CategoryId       (quantity of a category(or subtypes)  - no local var binding)   (CategorySpec)
+         - ResourceId           (previously declared resource)                                  (ResourceInstanceSpec)
         */
         
 
-        /*Timespec
-
-        (DateTimeV, DateTimeV) -> DateTimeVal start,  DateTimeVal end,  
-        (DateTimeV, DateTimeV) -> DateTimeVal start,  DateTimeVal end,  
+        //Extract timespec 
+        (DateTime start, DateTime end) = ComputeTimePeriod(query.Interval, envV, envH);
         
-        */
 
+
+        if (query.Recurrence != null){
+            (TimeSpan intervalBetween, DateTime recurrenceEnd) = ComputeRecurrencePeriod(query.Recurrence.Time, start, envV, envH);
+            
+            for (DateTime currentStart = start + intervalBetween; currentStart < recurrenceEnd; currentStart += intervalBetween) {
+
+                switch (query.Recurrence.Mode)
+                {
+                case RecurrenceMode.FLEXIBLE: //EvalReserveSEQ, with the queryData without the recurrence, start and end times for this itteration
+                        break;
+
+                    case RecurrenceMode.STRICT: //EvalReserveAND, , with the queryData without the recurrence, start and end times for this itteration
+                        break;
+                    
+                };
+                
+            }
+        }
+
+        //for compiler currently
         return new ReservationVal(new List<ReservationAtomVal>());
-
-        
     }
 
-    //(DateTimeVal, DateTimeVal) ComputeTimePeriod(DateTimeV st)
+    /// <summary> Returns a tupple of start DateTime and end DateTime in unwrapped, c# types </summary>
+    private static (DateTime, DateTime) ComputeTimePeriod(TimeSpec timeSpec, EnvV envV, EnvH envH){
+
+        //Evaluate the expressions within timespec
+        Value startVal = EvalExp(timeSpec.Start, envV, envH);
+        Value endMarkerVal = EvalExp(timeSpec.EndMarker, envV, envH);
+
+        //Return unwrapped c#
+        return (startVal, endMarkerVal) switch {
+            (DateTimeVal start, DateTimeVal to) => (start.Value, to.Value),
+            (DateTimeVal start, DurationVal For) =>(start.Value, start.Value + For.Value),
+            _ => throw new Exception("Invalid time specification.\n") 
+        };
+
+    }
+
+    /// <summary> Returns a tupple of start DateTime and end DateTime in unwrapped, c# types </summary>
+        private static (TimeSpan, DateTime) ComputeRecurrencePeriod(RecurrenceInterval recurrence, DateTime start, EnvV envV, EnvH envH)
+    {
+        
+        Value everyVal = EvalExp(recurrence.Every, envV, envH);
+        Value endMarkerVal = EvalExp(recurrence.EndMarker, envV, envH);
+
+        return (everyVal, endMarkerVal) switch {
+            
+            (DurationVal every, DateTimeVal until) => (every.Value, until.Value),
+
+            (DurationVal every, DurationVal For) => (every.Value, start + For.Value),
+
+         _ => throw new Exception("Invalid recurrence specification.\n") 
+            
+        };
+    }
 
     //Right operand Exp rightExp is intentionally not evaluated here. 
     private static ReservationVal EvalBinaryReserve(BinaryOperator op, ReservationVal leftReservation, Exp rightExp, EnvV envV, EnvH envH ) {

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -1,47 +1,36 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
 using RAL.AST;
-
 namespace RAL.Interpreter;
-
-/*
-Expression interpreter for arithmetic and boolean expressions.
-
-This interpreter evaluates AST expression nodes into runtime values.
-It currently supports:
-- Number, boolean, and string literals
-- Arithmetic operators: +, -, *, /
-- Numeric comparisons: <, >, <=, >=
-- Equality operators: ==, !=
-- Boolean operators: and, or, not
-
-The interpreter assumes that the type checker has already accepted the program.
-Runtime checks are still used for cases such as division by zero.
-*/
 
 public class Interpreter {
     private const float Epsilon = 0.00001f;
 
+    private static readonly ReservationRegistry reservationRegistry = ReservationRegistry.Instance();
+    private static readonly ResourceRegistry resourceRegistry = ResourceRegistry.Instance();
+
     //Evaluates a statement with pattern matching on the AST nodes
 
-    public static void EvalStmt(Stmt stmt, EnvV envV, EnvH envH)
+    public static void ExecStmt(Stmt stmt, EnvV envV, EnvH envH, EnvTem envTem)
     {
         switch(stmt)
         {   case Skip: break;
            
-            case Composite c: HandleComposite(c, envV, envH); break;
+            case Composite c: HandleComposite(c, envV, envH, envTem); break;
            
-            case If i: HandleIf(i, envV, envH); break;
+            case If i: HandleIf(i, envV, envH, envTem); break;
 
             case VarDecl vd: HandleVarDecl(vd, envV); break;
 
             case CategoryDecl cd: ExecCategoryDecl(cd, envH); break;
             case ResourceDecl rd: ExecResourceDecl(rd, envV, envH); break;
 
-            //case TemplateDecl
-            //case TemplateCall
+            case TemplateDecl td: ExecTemplateDecl(td, envTem); break;
+            case TemplateCall tc: ExecTemplateCall(tc, envV, envH, envTem); break;
 
             case Move m: ExecMove(m, envV); break;
 
-            //case Cancel c: 
+            case Cancel c: ExecCancel(c, envV, envH); break;
 
             case ExpStmt s: Console.WriteLine(EvalExp(s.Expression, envV, envH)); break;
 
@@ -62,7 +51,7 @@ public class Interpreter {
             Reference r => EvalReference(r, envV),
             
             Reserve reserveNode => EvalReserve(reserveNode, envV, envH),
-            // reschedule join
+            Reschedule rescheduleNode => HandleReschedule(rescheduleNode, envV, envH),
 
             Assignment a => EvalAssignment(a, envV, envH),
 
@@ -76,22 +65,22 @@ public class Interpreter {
 
     /* ________________________Statement Handlers______________________________*/
     
-    private static void HandleComposite (Composite c, EnvV envV, EnvH envH) {
+    private static void HandleComposite (Composite c, EnvV envV, EnvH envH, EnvTem envTem) {
         // Evaluates left subtree first
-        if(c.Stmt1 != null) EvalStmt(c.Stmt1, envV, envH);
+        ExecStmt(c.Stmt1, envV, envH, envTem);
         // Right subtree
-        if(c.Stmt2 != null) EvalStmt(c.Stmt2, envV, envH);        
+        ExecStmt(c.Stmt2, envV, envH, envTem);        
     }
 
-    private static void HandleIf(If ifNode, EnvV envV, EnvH envH) {
+    private static void HandleIf(If ifNode, EnvV envV, EnvH envH, EnvTem envTem) {
         //Evaluate condition to interpreter values
         Value condition = EvalExp(ifNode.Condition, envV, envH);
 
         //Downcast and extract bool value, guarenteed by typechecking. Bodies will be skip
         if (condition.AsBool())
-            EvalStmt(ifNode.ThenBody, envV.NewScope(), envH); //will be skip if empty {}
+            ExecStmt(ifNode.ThenBody, envV.NewScope(), envH, envTem); //will be skip if empty {}
         else 
-            EvalStmt(ifNode.ElseBody, envV.NewScope(), envH); //will be skip if empty {} or 'else' ommitted entirely in src code
+            ExecStmt(ifNode.ElseBody, envV.NewScope(), envH, envTem); //will be skip if empty {} or 'else' ommitted entirely in src code
     }
 
     private static void HandleVarDecl(VarDecl vdNode, EnvV envV) {
@@ -117,6 +106,15 @@ public class Interpreter {
 
             _ => throw new Exception("VarDecl node with unsupported type")
         };
+
+    private static void ExecCategoryDecl(CategoryDecl categoryDecl, EnvH envH) {
+
+        //Add it to the registry, such that resources of this category can be added to it
+        resourceRegistry.RegisterCategory(categoryDecl.CategoryId);        
+
+        //Relate it to its immediate super in envH
+        envH.EstablishRelation(categoryDecl.CategoryId, categoryDecl.ParentId);
+    }
 
     private static void ExecResourceDecl(ResourceDecl resDecl, EnvV envV, EnvH envH) {
 
@@ -174,27 +172,61 @@ public class Interpreter {
         envV.Bind(resDecl.Identifier, resource);
 
         //Add resource to the global registry, indexed by its category
-        ResourceRegistry.Instance().AddResource(resDecl.Type.Category, resource);
+        resourceRegistry.AddResource(resDecl.Type.Category, resource);
     }
 
-    private static void ExecCategoryDecl(CategoryDecl categoryDecl, EnvH envH) {
+    private static void ExecTemplateDecl(TemplateDecl node, EnvTem envTem) {
 
-        //Add it to the registry, such that resources of this category can be added to it
-        ResourceRegistry.Instance().RegisterCategory(categoryDecl.CategoryId);        
+        //Temporary list for extracting formal param names
+        List<string> parameterNames = [];
 
-        //Relate it to its immediate super in envH
-        envH.EstablishRelation(categoryDecl.CategoryId, categoryDecl.ParentId);
+        //Extract from the template declaration node
+        foreach (VarDecl varDecl in node.ParamList) {
+            parameterNames.Add(varDecl.Identifier);                                                
+        }
+
+        //Create new entry in Template Table (fTable)
+        envTem.Bind(node.TemplateId, parameterNames, node.TemplateBody); 
+    }
+
+    private static void ExecTemplateCall(TemplateCall node, EnvV envV, EnvH envH, EnvTem envTem) {
+        //New scope for params
+        EnvV templateScope = envV.NewScope();
+
+        (List<string> parameterNames, Stmt body) = envTem.Lookup(node.TemplateId);
+        
+        //Extract from the template declaration node
+        for (int i = 0; i < node.ArgList.Count; i++) {
+
+            //Evaluate the argument
+            Value evaluatedArg = EvalExp(node.ArgList[i], envV, envH);
+
+            //Bind actual parameters to formal parameters
+            templateScope.Bind(parameterNames[i], evaluatedArg);                                                
+        }
+
+        //Execute body
+        ExecStmt(body, templateScope, envH, envTem);        
     }
 
     private static void ExecMove(Move moveNode, EnvV envV) {
 
         ResourceVal resourceToMove = (ResourceVal) envV.Lookup(moveNode.ResourceId);
 
-        //Move to the righ category in the registry
-        ResourceRegistry.Instance().MoveResource(resourceToMove, moveNode.Type.Category); 
+        //Move to the right category in the registry
+        resourceRegistry.MoveResource(resourceToMove, moveNode.Type.Category); 
 
         //Update categoryId on the resource for easy, currently innit only. Fix
         resourceToMove.CategoryId = moveNode.Type.Category;
+    }
+
+    private static void ExecCancel(Cancel cancelNode, EnvV envV, EnvH envH) {
+
+        //Extract the reservation from the Expression
+        ReservationVal reservation = (ReservationVal) EvalExp(cancelNode.Reservation, envV, envH);
+
+        //Remove it from the central registry, also sets variable value to null
+        reservationRegistry.CancelReservation(reservation);
     }
 
     /*_____________________Expression Handlers_____________________*/
@@ -209,8 +241,12 @@ public class Interpreter {
         else {
             //Downcast justified by typechecker, exception -> type-checker logic issue
             ResourceVal resource = (ResourceVal) envV.Lookup(r.VariableId);
-            //Again an exception -> logic error in type-checker
-            return resource.Properties[r.PropertyId];
+            
+            if (resource.Properties.TryGetValue(r.PropertyId, out Value? val)) {
+                return val;
+            } else {
+                throw new MissingPropertyException($"Property '{r.PropertyId}' not found on resource '{resource.ResourceId}'.");
+            }
         }        
     }
 
@@ -261,7 +297,7 @@ public class Interpreter {
         (TimeSpan timeBetween, DateTime recurrenceEnd) = ComputeRecurrencePeriod(originalQuery.Recurrence.Time, originalStart, envV, envH);
         
         //Accumulate each atomic reservation request, starting from the second reservation occurrence.
-        for (DateTime slotStart = originalStart + timeBetween; slotStart < recurrenceEnd; slotStart += timeBetween) {
+        for (DateTime slotStart = originalStart + timeBetween; slotStart <= recurrenceEnd; slotStart += timeBetween) {
 
             // create identical reservation requests with start and end time shifted by the specified amount (timeBetween: e.g. 'every 7d')
             timeSlots.Add(baseQuery with {Start = slotStart, End = slotStart + duration}); 
@@ -283,16 +319,17 @@ public class Interpreter {
     }
 
      private static ReservationVal EvalReserveAtom(ResolvedQuery query, EnvV envV, EnvH envH) {
-        /*var validCombination = FindAvailableResources(query, envV, envH);
-        
-        if (validCombination.Any()) {
-            // Commit to registry
-            ReservationVal newReservation = new ReservationVal(validCombination);
-            ReservationRegistry.Instance().AddReservation(newReservation);
-            return newReservation;
+        var validCombinations = QueryEvaluator.EvaluateQuery(query, envV, envH);
+
+         if (validCombinations.Any()) {
+        var selectedCombination = validCombinations.First();
+        var atom = new ReservationAtomVal(selectedCombination, new DateTimeVal(query.Start), new DateTimeVal(query.End));
+        var newReservation = new ReservationVal(new List<ReservationAtomVal> { atom });
+
+        reservationRegistry.RegisterReservation(newReservation);
+        return newReservation;
         }
-        */
-        
+
         return new ReservationVal(new List<ReservationAtomVal>()); // Failed
     }
 
@@ -313,8 +350,7 @@ public class Interpreter {
     }
 
     /// <summary> Returns a tupple of start DateTime and end DateTime in unwrapped, c# types </summary>
-        private static (TimeSpan, DateTime) ComputeRecurrencePeriod(RecurrenceInterval recurrence, DateTime start, EnvV envV, EnvH envH)
-    {
+    private static (TimeSpan, DateTime) ComputeRecurrencePeriod(RecurrenceInterval recurrence, DateTime start, EnvV envV, EnvH envH) {
         
         Value everyVal = EvalExp(recurrence.Every, envV, envH);
         Value endMarkerVal = EvalExp(recurrence.EndMarker, envV, envH);
@@ -385,7 +421,7 @@ public class Interpreter {
         else {
             //Combine reservations to a composite, in the original
             leftReservation.Reservations.AddRange(rightReservation.Reservations);
-
+            ReservationRegistry.Instance().CancelReservation(rightReservation);
             //return the reservation which is now interpreted as a composite
             return leftReservation;
         }
@@ -397,8 +433,34 @@ public class Interpreter {
 
         //Combine reservations to a composite, in the original - wether either were empty
         leftReservation.Reservations.AddRange(rightReservation.Reservations);
-        
+        ReservationRegistry.Instance().CancelReservation(rightReservation);
         return leftReservation;//stub for compiler errors  
+    }
+
+    private static Value HandleReschedule(Reschedule node, EnvV envV, EnvH envH) {
+
+        //Evaluate exp node to runtime reservation
+        ReservationVal reservation = (ReservationVal) EvalExp(node.Reservation, envV, envH);
+
+        //Not possible for composite reservations
+        if (reservation.IsComposite() || reservation.Failed()) return new ReservationVal([]); //Indicates failure
+
+        //Simple reservations, extract it
+        ReservationAtomVal atomicReservation = reservation.Reservations[0];
+
+        //Extract requested time slot. _ discards the third value of the returned 3-tuple
+        (DateTime requestedStart, DateTime requestedEnd, _) = ComputeTime(node.NewTimeInterval, envV, envH);
+
+        //If any of the resources are unavailable, indicate failure each resource's availability in newly requested time
+        if (atomicReservation.Resources.Any(resource => !reservationRegistry.IsAvailable(resource, requestedStart, requestedEnd)))
+            return new ReservationVal([]); //Indicates failure
+        
+        //Update time properties of the existing reservation
+        atomicReservation.Start = new DateTimeVal(requestedStart);
+        atomicReservation.End = new DateTimeVal(requestedEnd);
+
+        //Return the entire reservation
+        return reservation; 
     }
 
     private static Value EvalBinary(BinaryOperation exp, EnvV envV, EnvH envH) {
@@ -580,5 +642,9 @@ public class Interpreter {
         // Because Number is represented as float, zero is also checked using epsilon.
         if (NumberEquals(value, 0f))
             throw new Exception($"Line {lineNumber}: Division by zero.");
+    }
+
+    public class MissingPropertyException : Exception {
+        public MissingPropertyException(string message) : base(message) {}
     }
 }

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -260,17 +260,22 @@ public class Interpreter {
         List<ResolvedQuery> timeSlots = new() { baseQuery };
         (TimeSpan timeBetween, DateTime recurrenceEnd) = ComputeRecurrencePeriod(originalQuery.Recurrence.Time, originalStart, envV, envH);
         
-        //Accumulate each simple reservation request, starting from the second reservation occurrence.
+        //Accumulate each atomic reservation request, starting from the second reservation occurrence.
         for (DateTime slotStart = originalStart + timeBetween; slotStart < recurrenceEnd; slotStart += timeBetween) {
+
             // create identical reservation requests with start and end time shifted by the specified amount (timeBetween: e.g. 'every 7d')
             timeSlots.Add(baseQuery with {Start = slotStart, End = slotStart + duration}); 
         }
 
         //Skip evaluating the first reservation in the recurrence list as it has already been evaluated and stored in 'result'
         foreach (ResolvedQuery slot in timeSlots.Skip(1)) { 
+
             result = originalQuery.Recurrence.Mode switch {
+
                 RecurrenceMode.STRICT => EvalReserveAND(result, () => EvalReserveAtom(slot, envV, envH)),
+
                 RecurrenceMode.FLEXIBLE => EvalReserveSEQ(result, () => EvalReserveAtom(slot, envV, envH)),
+
                 _ => throw new Exception("Unknown recurrence mode.")
             };
         }

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using System.Runtime.InteropServices;
 using RAL.AST;
 namespace RAL.Interpreter;
 
@@ -9,8 +7,7 @@ public class Interpreter {
     private static readonly ReservationRegistry reservationRegistry = ReservationRegistry.Instance();
     private static readonly ResourceRegistry resourceRegistry = ResourceRegistry.Instance();
 
-    //Evaluates a statement with pattern matching on the AST nodes
-
+    //Executes a statement with pattern matching on the AST nodes
     public static void ExecStmt(Stmt stmt, EnvV envV, EnvH envH, EnvTem envTem)
     {
         switch(stmt)
@@ -34,7 +31,7 @@ public class Interpreter {
 
             case ExpStmt s: Console.WriteLine(EvalExp(s.Expression, envV, envH)); break;
 
-            // case Availability av
+            case Availability av: HandleAvailability(av, envV, envH); break;
             default: throw new Exception($"Unknown Statement: " + stmt.ToString());
         }
     }
@@ -50,13 +47,15 @@ public class Interpreter {
 
             Reference r => EvalReference(r, envV),
             
+            Assignment a => EvalAssignment(a, envV, envH),
+            
             Reserve reserveNode => EvalReserve(reserveNode, envV, envH),
+            
             Reschedule rescheduleNode => HandleReschedule(rescheduleNode, envV, envH),
 
-            Assignment a => EvalAssignment(a, envV, envH),
-
-            UnaryOperation u => EvalUnary(u, envV, envH),
             BinaryOperation b => EvalBinary(b, envV, envH), //  (reserve1, reserve2) defined for or, and, seq. Returns a composite reservation
+            
+            UnaryOperation u => EvalUnary(u, envV, envH),
 
 
             _ => throw new Exception($"Line {exp.LineNumber}: Unsupported expression.")
@@ -229,6 +228,22 @@ public class Interpreter {
         reservationRegistry.CancelReservation(reservation);
     }
 
+     private static void HandleAvailability(Availability av, EnvV envV, EnvH envH) {
+        (DateTime originalStart, DateTime originalEnd, TimeSpan duration) = ComputeTime(av.Query.Interval, envV, envH);
+        ResolvedQuery baseQuery = new ResolvedQuery(av.Query.ResourceSpecs, originalStart, originalEnd, av.Query.Condition);
+        
+        var validCombinations = QueryEvaluator.EvaluateQuery(baseQuery, envV, envH);
+        
+        if (validCombinations.Any()) {
+            Console.WriteLine($"Availability check succeeded for period {originalStart} to {originalEnd}. Valid combinations found:");
+            foreach(var combo in validCombinations) {
+                Console.WriteLine("  [" + string.Join(", ", combo.Select(r => r.ResourceId)) + "]");
+            }
+        } else {
+            Console.WriteLine("Availability check failed: No resources satisfy the query.");
+        }
+    }
+
     /*_____________________Expression Handlers_____________________*/
 
     private static Value EvalReference(Reference r, EnvV envV) {
@@ -321,13 +336,13 @@ public class Interpreter {
      private static ReservationVal EvalReserveAtom(ResolvedQuery query, EnvV envV, EnvH envH) {
         var validCombinations = QueryEvaluator.EvaluateQuery(query, envV, envH);
 
-         if (validCombinations.Any()) {
-        var selectedCombination = validCombinations.First();
-        var atom = new ReservationAtomVal(selectedCombination, new DateTimeVal(query.Start), new DateTimeVal(query.End));
-        var newReservation = new ReservationVal(new List<ReservationAtomVal> { atom });
+        if (validCombinations.Any()) {
+            var selectedCombination = validCombinations.First();
+            var atom = new ReservationAtomVal(selectedCombination, new DateTimeVal(query.Start), new DateTimeVal(query.End));
+            var newReservation = new ReservationVal(new List<ReservationAtomVal> { atom });
 
-        reservationRegistry.RegisterReservation(newReservation);
-        return newReservation;
+            reservationRegistry.RegisterReservation(newReservation);
+            return newReservation;
         }
 
         return new ReservationVal(new List<ReservationAtomVal>()); // Failed
@@ -412,6 +427,7 @@ public class Interpreter {
             leftReservation.Reservations.Clear();
 
             //Remove from register
+            reservationRegistry.CancelReservation(leftReservation);
             
             //return a reservationVal with an empty list -> indicates failed reservation attempt
             return leftReservation;
@@ -421,7 +437,7 @@ public class Interpreter {
         else {
             //Combine reservations to a composite, in the original
             leftReservation.Reservations.AddRange(rightReservation.Reservations);
-            ReservationRegistry.Instance().CancelReservation(rightReservation);
+            reservationRegistry.CancelReservation(rightReservation);
             //return the reservation which is now interpreted as a composite
             return leftReservation;
         }
@@ -433,7 +449,7 @@ public class Interpreter {
 
         //Combine reservations to a composite, in the original - wether either were empty
         leftReservation.Reservations.AddRange(rightReservation.Reservations);
-        ReservationRegistry.Instance().CancelReservation(rightReservation);
+        reservationRegistry.CancelReservation(rightReservation);
         return leftReservation;//stub for compiler errors  
     }
 

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -248,7 +248,7 @@ public class Interpreter {
         //Treat all queries equally. Wether an AST without recurring or simulated for requrrence         
         ResolvedQuery baseQuery = new ResolvedQuery(originalQuery.ResourceSpecs, originalStart, originalEnd, originalQuery.Condition);
 
-        ReservationVal result = ExecuteSingleReservation(baseQuery, envV, envH); 
+        ReservationVal result = EvalReserveAtom(baseQuery, envV, envH); 
 
         //Case 1: Simple reserve node, no recurring
         if (originalQuery.Recurrence == null) {
@@ -262,21 +262,22 @@ public class Interpreter {
         
         //Accumulate each simple reservation request, starting from the second reservation occurrence.
         for (DateTime slotStart = originalStart + timeBetween; slotStart < recurrenceEnd; slotStart += timeBetween) {
-
+            // create identical reservation requests with start and end time shifted by the specified amount (timeBetween: e.g. 'every 7d')
             timeSlots.Add(baseQuery with {Start = slotStart, End = slotStart + duration}); 
         }
 
-        foreach (ResolvedQuery slot in timeSlots.Skip(1)) {
+        //Skip evaluating the first reservation in the recurrence list as it has already been evaluated and stored in 'result'
+        foreach (ResolvedQuery slot in timeSlots.Skip(1)) { 
             result = originalQuery.Recurrence.Mode switch {
-                RecurrenceMode.STRICT => EvalReserveAND(result, () => ExecuteSingleReservation(slot, envV, envH)),
-                RecurrenceMode.FLEXIBLE => EvalReserveSEQ(result, () => ExecuteSingleReservation(slot, envV, envH)),
-                _ => throw new Exception("Unknown recurrence mode")
+                RecurrenceMode.STRICT => EvalReserveAND(result, () => EvalReserveAtom(slot, envV, envH)),
+                RecurrenceMode.FLEXIBLE => EvalReserveSEQ(result, () => EvalReserveAtom(slot, envV, envH)),
+                _ => throw new Exception("Unknown recurrence mode.")
             };
         }
         return result;
     }
 
-     private static ReservationVal ExecuteSingleReservation(ResolvedQuery query, EnvV envV, EnvH envH) {
+     private static ReservationVal EvalReserveAtom(ResolvedQuery query, EnvV envV, EnvH envH) {
         /*var validCombination = FindAvailableResources(query, envV, envH);
         
         if (validCombination.Any()) {
@@ -298,8 +299,8 @@ public class Interpreter {
         Value endMarkerVal = EvalExp(timeSpec.EndMarker, envV, envH);
 
         //Return unwrapped c#
-        return (startVal, endMarkerVal) switch {   //start dt  ,    end dt   , duration of reservation
-            (DateTimeVal start, DateTimeVal to) => (start.Value, to.Value,  to.Value - start.Value),
+        return (startVal, endMarkerVal) switch {   //start dt,    end dt,  duration of reservation
+            (DateTimeVal start, DateTimeVal to) => (start.Value, to.Value, to.Value - start.Value),
             (DateTimeVal start, DurationVal For) =>(start.Value, start.Value + For.Value, For.Value),
             _ => throw new Exception("Invalid time specification.\n") 
         };

--- a/src/RAL/Interpreter/Interpreter.cs
+++ b/src/RAL/Interpreter/Interpreter.cs
@@ -1,7 +1,4 @@
-using System.Dynamic;
-using Microsoft.Win32;
 using RAL.AST;
-using RAL.TC;
 
 namespace RAL.Interpreter;
 
@@ -64,7 +61,7 @@ public class Interpreter {
 
             Reference r => EvalReference(r, envV),
             
-            //Reserve reserveNode => EvalReserve(reserveNode.Query,)
+            Reserve reserveNode => EvalReserve(reserveNode.Query),
             // reschedule join
 
             Assignment a => EvalAssignment(a, envV, envH),
@@ -94,7 +91,7 @@ public class Interpreter {
         if (condition.AsBool())
             EvalStmt(ifNode.ThenBody, envV.NewScope(), envH); //will be skip if empty {}
         else 
-            EvalStmt(ifNode.ElseBody, envV.NewScope(), envH); //will be skip if excluded or empty {}
+            EvalStmt(ifNode.ElseBody, envV.NewScope(), envH); //will be skip if empty {} or 'else' ommitted entirely in src code
     }
 
     private static void HandleVarDecl(VarDecl vdNode, EnvV envV) {
@@ -107,8 +104,7 @@ public class Interpreter {
 
     /// <summary> Returns default values of uninitialized variables </summary>
     private static Value GetDefaultValue(TypeT type) => 
-    type switch 
-        {
+    type switch {
             BoolT => new BoolVal(false),
             NumberT => new NumberVal(0),
             StringT => new StringVal(""),
@@ -241,6 +237,29 @@ public class Interpreter {
         //Either case: value of an assignment is the right hand side
         return value;
     }
+
+    private static ReservationVal EvalReserve(QueryData query) {
+
+        /* Resource spec contains a list of objects guarenteed by grammar to be 
+         - a * CategoryId id    (quantity of a category (or subtypes) + local var binding)
+         - a * CategoryId       (quantity of a category(or subtypes)  - no local var binding)
+         - ResourceId           (previously declared resource)
+        */
+        
+
+        /*Timespec
+
+        (DateTimeV, DateTimeV) -> DateTimeVal start,  DateTimeVal end,  
+        (DateTimeV, DateTimeV) -> DateTimeVal start,  DateTimeVal end,  
+        
+        */
+
+        return new ReservationVal(new List<ReservationAtomVal>());
+
+        
+    }
+
+    //(DateTimeVal, DateTimeVal) ComputeTimePeriod(DateTimeV st)
 
     //Right operand Exp rightExp is intentionally not evaluated here. 
     private static ReservationVal EvalBinaryReserve(BinaryOperator op, ReservationVal leftReservation, Exp rightExp, EnvV envV, EnvH envH ) {

--- a/src/RAL/Interpreter/QueryEvaluator.cs
+++ b/src/RAL/Interpreter/QueryEvaluator.cs
@@ -1,0 +1,188 @@
+using RAL.AST;
+namespace RAL.Interpreter;
+
+internal static class QueryEvaluator {
+    /// <summary> Evaluates an atomic query an returns a list of all valid combinations of resources.  
+    /// Atomic, since recurrence has been pulled out. 
+    /// (Availability, Reservation) </summary>
+    internal static IEnumerable<List<ResourceVal>> EvaluateQuery(ResolvedQuery query, EnvV envV, EnvH envH) {
+
+        // Step 1: List of all candidate combinations for all resource specification. 
+        List<ResolvedSpec>? groupedCandidateCombinations = ResolveAllResourceSpecs(query, envV, envH);
+        
+        if (groupedCandidateCombinations == null)
+            return [];
+
+        // Step 2: Cartesian product of all resource specs' combinations, unwraps resolvedspec
+        var cartesianProduct = CartesianProduct(groupedCandidateCombinations.Select(resolvedSpec => resolvedSpec.CandidateCombinations));
+
+        // Step 3: Ensure resources across specs are distinct
+        var validAssignments = cartesianProduct.Where(assignment => {
+            var flat = assignment.SelectMany(r => r).ToList();
+            return flat.Distinct().Count() == flat.Count;
+        });
+
+        // Step 4: Evaluate Condition if present
+        if (query.Condition != null) {
+            validAssignments = validAssignments.Where(assignment => {
+                var bindingSets = new List<KeyValuePair<string, List<ResourceVal>>>();
+                for (int i = 0; i < assignment.Count; i++) {
+                    if (groupedCandidateCombinations[i].LocalBinding != null) {
+                    bindingSets.Add(new KeyValuePair<string, List<ResourceVal>>(
+                        groupedCandidateCombinations[i].LocalBinding!,
+                        assignment[i]));
+                    }
+                }
+
+                if (!bindingSets.Any()) {
+                    // No bound variables; evaluate once
+                    try {
+                        return Interpreter.EvalExp(query.Condition, envV, envH).AsBool();
+                    } catch (Interpreter.MissingPropertyException) {
+                        return false;
+                    }
+                }
+
+                // Generate Cartesian product of individual resources for the bound variables
+                var elementSets = bindingSets.Select(kvp => kvp.Value.Select(r => new KeyValuePair<string, Value>(kvp.Key, r)));
+                var bindingCombinations = CartesianProduct(elementSets);
+
+                // The condition must be true for EVERY element combination
+                foreach (var bindCombo in bindingCombinations) {
+                    EnvV scope = envV.NewScope();
+                    foreach (var binding in bindCombo) {
+                        scope.Bind(binding.Key, binding.Value);
+                    }
+                    try {
+                        if (!Interpreter.EvalExp(query.Condition, scope, envH).AsBool()) {
+                            return false;
+                        }
+                    } catch (Interpreter.MissingPropertyException) { 
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+
+        // Return flattened list of resources for each valid assignment
+        return validAssignments.Select(assignment => assignment.SelectMany(r => r).ToList());
+    }
+
+    //i.e. resolve re. (re and re...)
+    private static List<ResolvedSpec>? ResolveAllResourceSpecs(ResolvedQuery query, EnvV envV, EnvH envH) {
+
+        List<ResolvedSpec> groupedCandidateCombinations = new();
+
+         // Step 1: Find all valid resource combinations for each ResourceSpec (r | a rc[id])
+        foreach (ResourceSpec spec in query.ResourceSpecs) {
+            
+            // for one ResourceSpec (r | a rc[id])
+            ResolvedSpec? candidateCombinations = spec switch {
+                
+                //Case 1 - named resourceId: i.e. room204
+                ResourceInstanceSpec resourceInstance => ResolveInstanceSpec(resourceInstance, query.Start, query.End, envV),
+                
+                //Case 2 & 3: [a rc], [a rc id] respectively
+                CategorySpec categorySpec => ResolveCategorySpec(categorySpec, query.Start, query.End, envV, envH),
+
+                _ => throw new Exception($"Invalid resource specification.")
+            };
+
+            //If any one spec fails (not available at requested time) -> fail the entire request immediately. re and re
+            if (candidateCombinations == null)
+                return null;
+
+            groupedCandidateCombinations.Add(candidateCombinations);
+
+        }
+        //If this is reached, each spec is satisfied based solely on the given timeslot (condition yet to be evaluated)
+        return groupedCandidateCombinations;
+    }
+    
+    private static ResolvedSpec? ResolveInstanceSpec(ResourceInstanceSpec spec, DateTime requestedStart, DateTime requestedEnd, EnvV envV) {
+        
+        //lookup in envV - ResourceVal guaranteed by typechecker
+        ResourceVal resource = (ResourceVal)envV.Lookup(spec.ResourceId);
+
+        // Required instance not available at given time. Whole query fails fast.
+        if (! ReservationRegistry.Instance().IsAvailable(resource, requestedStart, requestedEnd) )
+            return null;
+
+        //Available
+        return new ResolvedSpec(
+            //a named resource has only one possible combination (itself). wraped in double lists for equal treatment.
+            CandidateCombinations:
+            [
+                [resource]
+            ],
+            LocalBinding: null //impossible by concrete syntax
+        );
+    }
+
+    private static ResolvedSpec? ResolveCategorySpec(CategorySpec catSpec, DateTime requestedStart, DateTime requestedEnd, EnvV envV, EnvH envH) {
+        //extract a
+        int quantity = (int)((NumberVal)Interpreter.EvalExp(catSpec.Quantity, envV, envH)).Value;
+
+        IEnumerable<string> subCategories = envH.GetSubCategories(catSpec.CategoryId);
+        List<ResourceVal> availableResources =
+            ResourceRegistry.Instance()
+                .GetAllResourcesInCategorySubtree(subCategories)
+                .Where(resource => ReservationRegistry.Instance().IsAvailable(resource, requestedStart, requestedEnd))
+                .ToList();
+
+        var combinations = GetCombinations(availableResources, quantity).ToList();
+
+        if (combinations.Count == 0)
+            return null;
+
+        return new ResolvedSpec(
+            CandidateCombinations: combinations,
+            //as: like a typecast, but returns null if not possible rather than throwing exception. Null-safe operator
+            LocalBinding: (catSpec as CategorySpecWithBinding)?.LocalBindingId);
+    }
+
+
+    /// <summary> Generates all combinations of size 'quantity' from a list of resources. </summary>
+    private static IEnumerable<List<ResourceVal>> GetCombinations(List<ResourceVal> resources, int quantity) {
+        if (quantity == 0)                yield return new List<ResourceVal>();
+        else if (resources.Count == quantity) yield return new List<ResourceVal>(resources);
+        else if (resources.Count > quantity) {
+            ResourceVal head = resources[0];
+            List<ResourceVal> tail = resources.GetRange(1, resources.Count - 1);
+
+            // Include head
+            foreach (List<ResourceVal> combination in GetCombinations(tail, quantity - 1)) {
+                List<ResourceVal> newCombination = new List<ResourceVal>(combination);
+                newCombination.Insert(0, head);
+                yield return newCombination;
+            }
+
+            // Exclude head
+            foreach (List<ResourceVal> combination in GetCombinations(tail, quantity)) {
+                yield return combination;
+            }
+        }
+    }
+
+    /// <summary> Generates the Cartesian product of a sequence of sequences. </summary>
+    private static IEnumerable<List<T>> CartesianProduct<T>(IEnumerable<IEnumerable<T>> sequences) {
+        IEnumerable<List<T>> result = new List<List<T>> { new List<T>() };
+
+        foreach (IEnumerable<T> sequence in sequences) {
+            result =
+                from partial in result
+                from item in sequence
+                select partial.Append(item).ToList();
+        }
+
+        return result;
+    }
+
+    /// <summary> List of all candidate combinations(a list itself) for ONE resource spec: (r | a rc [id]) /// </summary>
+    private record ResolvedSpec (
+        List<List<ResourceVal>> CandidateCombinations,
+        string? LocalBinding
+    );
+
+}

--- a/src/RAL/Interpreter/ReservationRegistry.cs
+++ b/src/RAL/Interpreter/ReservationRegistry.cs
@@ -18,5 +18,33 @@ public class ReservationRegistry
     //Method to access singleton, which is otherwise private
     public static ReservationRegistry Instance() { return instance; }
 
+    /// <summary> Interface for registering a given reservation </summary>
+    public void RegisterReservation(ReservationVal reservation) {
+        _registry.Add(reservation);
+    }
+
+    /// <summary> Interface for cancelling a given reservation </summary>
+    public void CancelReservation(ReservationVal reservation) {
+        _registry.Remove(reservation);        
+    }
+
+    /// <summary> Checks weather a specific resource is available in the given time slot </summary>
+    public bool IsAvailable(ResourceVal resource, DateTime requestedStart, DateTime requestedEnd) {
+        //Negated overlap check
+        return 
+            !(_registry
+                //From each possibly composite Reservation, extract all inner atomic reservations into one flat list<ResourceAtomVal>
+                .SelectMany(resourceVal => resourceVal.Reservations)
+
+                //Foreach resourceAtomVal, which may contain a list of resources for a given timeslot. (re and re)
+                .Any(reservationAtomVal => 
+                    //is the resource reserved?
+                    reservationAtomVal.Resources.Contains(resource) &&
+                    //Overlaps?
+                    requestedStart < reservationAtomVal.End.Value &&
+                    requestedEnd > reservationAtomVal.Start.Value
+                )          
+            );
+    }
 
 }

--- a/src/RAL/Interpreter/ReservationRegistry.cs
+++ b/src/RAL/Interpreter/ReservationRegistry.cs
@@ -25,7 +25,10 @@ public class ReservationRegistry
 
     /// <summary> Interface for cancelling a given reservation </summary>
     public void CancelReservation(ReservationVal reservation) {
-        _registry.Remove(reservation);        
+        _registry.Remove(reservation);
+
+        //Make a variable's value indicate 'null' reservation
+        reservation.Reservations.Clear();        
     }
 
     /// <summary> Checks weather a specific resource is available in the given time slot </summary>
@@ -45,6 +48,16 @@ public class ReservationRegistry
                     requestedEnd > reservationAtomVal.Start.Value
                 )          
             );
+    }
+    public override string ToString() {
+        if (_registry.Count == 0)
+            return "=== Reservation Registry ===\n(empty)\n";
+
+        string reservations = string.Join(
+            "\n--------------------------------------------------\n",
+            _registry.Select((reservationVal, i) => $"Reservation #{i + 1}\n{reservationVal}"));
+
+        return $"=== Reservation Registry ===\n\n{reservations}\n\n=== End Registry ===";
     }
 
 }

--- a/src/RAL/Interpreter/ResolvedQuery.cs
+++ b/src/RAL/Interpreter/ResolvedQuery.cs
@@ -1,0 +1,12 @@
+using RAL.AST;
+
+namespace RAL.Interpreter;
+
+//Represents data for a single reservation attempt for a specific, calculated timeframe.
+//Purpose: Decouple runtime execution from AST, particularly due to recurrence. */
+internal record ResolvedQuery(
+    IReadOnlyList<ResourceSpec> ResourceSpecs, //specs come from the AST and must never be mutated at runtime 
+    DateTime Start,
+    DateTime End,
+    Exp? Condition
+);

--- a/src/RAL/Interpreter/ResourceRegistry.cs
+++ b/src/RAL/Interpreter/ResourceRegistry.cs
@@ -32,6 +32,10 @@ public class ResourceRegistry {
         GetResourceList(categoryId).Add(resource);
     }
 
+    public IEnumerable<ResourceVal> GetAllResourcesInCategorySubtree(IEnumerable<string> subCategories)
+        => subCategories.SelectMany(category => GetResourceList(category));
+
+
     private HashSet<ResourceVal> GetResourceList(string categoryId) {
         
         //All registered categories must have a list to return, wether empty or not. Exception wanted
@@ -45,9 +49,9 @@ public class ResourceRegistry {
         _registry.Add(categoryId, new HashSet<ResourceVal>());
     }
 
-    public override string ToString() {
+     public override string ToString() {
 
-        string s = "____________Printing Registry:____________\n\n";
+        string s = "____________Printing Resource Registry:____________\n\n";
 
         foreach (var category in _registry) {
             s += $"__In {category.Key} category:__\n\n";
@@ -56,7 +60,7 @@ public class ResourceRegistry {
                 s += resource.ToString();
             }
 
-            s += $"__End of {category.Key} category__\n\n";;
+            s += $"\n__End of {category.Key} category__\n\n";;
         }
 
         s+= "____________Registry Printing Done____________";

--- a/src/RAL/Interpreter/ResourceRegistry.cs
+++ b/src/RAL/Interpreter/ResourceRegistry.cs
@@ -12,7 +12,7 @@ public class ResourceRegistry {
 
     //Private constructor initializing registry data structure
     private ResourceRegistry() {
-
+                                //categoryId
         _registry = new Dictionary<string, HashSet<ResourceVal>>() { { "Resource", new HashSet<ResourceVal>() } };
         
     }

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -14,10 +14,7 @@ using System.Globalization;
  - AST nodes describe the source program.
  - Runtime values are the result of evaluating expressions.
 */
-
-
-public abstract record Value
-{
+public abstract record Value {
     /*Default methods to avoid poluting interpreter.cs with downcasts. 
       Typechecking should have guarded possible exceptions */
     public bool AsBool()  => ((BoolVal)this).Value; 
@@ -26,32 +23,27 @@ public abstract record Value
 
 /* For now, Number is represented as float because the language 
    uses one Number type for both integer-like and decimal values. */
-record NumberVal(float Value) : Value
-{
+record NumberVal(float Value) : Value {
     // "G" keeps the output compact, e.g. 2 instead of 2.000000
     public override string ToString() => Value.ToString("G");
 }
 
-record BoolVal(bool Value) : Value
-{
+record BoolVal(bool Value) : Value {
     // Match common DSL syntax: true / false instead of True / False
     public override string ToString() => Value.ToString().ToLower();
 }
 
-record StringVal(string Value) : Value
-{
+record StringVal(string Value) : Value {
     public override string ToString() => Value;
 }
 
 /*________________ Time ______________*/
-public record DateTimeVal(DateTime Value) : Value
-{
+public record DateTimeVal(DateTime Value) : Value {
     // Returns the DateTime formatted as custom "dd/MM-yyyy HH:mm" using French (fr-FR) culture.
     public override string ToString() => Value.ToString("dd/MM-yyyy HH:mm", new CultureInfo("fr-FR"));
 }
 
-public record DurationVal(TimeSpan Value) : Value
-{
+public record DurationVal(TimeSpan Value) : Value {
     public override string ToString() => Value.ToString();
 }
 
@@ -59,7 +51,6 @@ public record DurationVal(TimeSpan Value) : Value
 
 //CategoryId for move to avoid linear search of every list in Categories,     property id -> value
 public record ResourceVal(string ResourceId, string CategoryId, Dictionary<string , Value> Properties) : Value {
-
     public string CategoryId {get; set;} = CategoryId; // this.CategoryId set to parameter CategoryId
     
     public override string ToString() {
@@ -72,14 +63,7 @@ public record ResourceVal(string ResourceId, string CategoryId, Dictionary<strin
     }
 }
 
-
-/*
-//CategoryId -> Resources within it. EnvH is still needed.
-Dictionary<string, List<ResourceVal>> ResourcesByCategory
-*/
-
-
-// 2 DoubleRoom dr and 3 Room ... time ...
+// 2 DoubleRoom dr and 3 Room ... time 
 //Alternative one resourceVal and make it composite reservation i.e. ReservationVal, drawback cannot reschedule
 public record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateTimeVal End ) {
     public DateTimeVal Start {get; set;} = Start;
@@ -92,13 +76,9 @@ public record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start
     }
 }
 
-
-/// <summary>
-/// All reservations are treated equally like this. 
-/// An atomic reservation, has a list length 1
-/// An empty list indicates a "rejected" reservation attempt 
-/// </summary>
-/// <param name="Reservations"></param>
+/// <summary> All reservations are treated equally like this. 
+/// An atomic reservation, has a list of length 1.
+/// An empty list indicates a "failed" reservation attempt. </summary>
 public record ReservationVal( List<ReservationAtomVal> Reservations) : Value {
 
     public bool Failed() { return this.Reservations.Count == 0; }
@@ -114,10 +94,4 @@ public record ReservationVal( List<ReservationAtomVal> Reservations) : Value {
             Reservations.Select((reservationAtom, i) => $"Reservation Atom #{i + 1}\n{reservationAtom}")
         );
     }
-
 }
-
-
-/*  
-List<ReservationVal> Calendar = new();
-*/

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -1,6 +1,5 @@
 namespace RAL.Interpreter;
 
-using System.ComponentModel;
 using System.Globalization;
 
 /* Runtime values used by the interpreter.
@@ -55,8 +54,6 @@ record DurationVal(TimeSpan Value) : Value
 {
     public override string ToString() => Value.ToString();
 }
-
-
 
 //EnvV, EnvF, EnvH
 

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -61,19 +61,15 @@ public record DurationVal(TimeSpan Value) : Value
 public record ResourceVal(string ResourceId, string CategoryId, Dictionary<string , Value> Properties) : Value {
 
     public string CategoryId {get; set;} = CategoryId; // this.CategoryId set to parameter CategoryId
-    public override string ToString() {
     
-        string r = $"{CategoryId}: {ResourceId} {{ \n";
+    public override string ToString() {
+        
+        string props = string.Join(
+            ", " , 
+            Properties.Select(p => $"{p.Key}: {p.Value}") );
 
-        foreach (var property in Properties) {
-
-            r += $"  {property.Key}: " + property.Value.ToString() + "\n";
-        }
-
-        r+= "} \n\n";
-
-        return r;
-    } 
+        return $"{CategoryId}({ResourceId}) [{props}]";
+    }
 }
 
 
@@ -88,6 +84,12 @@ Dictionary<string, List<ResourceVal>> ResourcesByCategory
 public record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateTimeVal End ) {
     public DateTimeVal Start {get; set;} = Start;
     public DateTimeVal End {get; set;} = End;
+
+    public override string ToString() {
+        string resources = string.Join("\n    - ", Resources.Select(r => r.ToString()));
+
+        return $"Time: {Start} -> {End}\n  Resources: - {resources}";
+    }
 }
 
 
@@ -100,6 +102,18 @@ public record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start
 public record ReservationVal( List<ReservationAtomVal> Reservations) : Value {
 
     public bool Failed() { return this.Reservations.Count == 0; }
+
+    public bool IsComposite() { return this.Reservations.Count > 1; }
+
+    public override string ToString() {
+        if (Failed())
+            return "FAILED RESERVATION";
+
+        return string.Join(
+            "\n\n",
+            Reservations.Select((reservationAtom, i) => $"Reservation Atom #{i + 1}\n{reservationAtom}")
+        );
+    }
 
 }
 

--- a/src/RAL/Interpreter/Values.cs
+++ b/src/RAL/Interpreter/Values.cs
@@ -44,13 +44,13 @@ record StringVal(string Value) : Value
 }
 
 /*________________ Time ______________*/
-record DateTimeVal(DateTime Value) : Value
+public record DateTimeVal(DateTime Value) : Value
 {
     // Returns the DateTime formatted as custom "dd/MM-yyyy HH:mm" using French (fr-FR) culture.
     public override string ToString() => Value.ToString("dd/MM-yyyy HH:mm", new CultureInfo("fr-FR"));
 }
 
-record DurationVal(TimeSpan Value) : Value
+public record DurationVal(TimeSpan Value) : Value
 {
     public override string ToString() => Value.ToString();
 }
@@ -85,7 +85,7 @@ Dictionary<string, List<ResourceVal>> ResourcesByCategory
 
 // 2 DoubleRoom dr and 3 Room ... time ...
 //Alternative one resourceVal and make it composite reservation i.e. ReservationVal, drawback cannot reschedule
-record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateTimeVal End ) {
+public record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateTimeVal End ) {
     public DateTimeVal Start {get; set;} = Start;
     public DateTimeVal End {get; set;} = End;
 }
@@ -97,7 +97,7 @@ record ReservationAtomVal( List<ResourceVal> Resources, DateTimeVal Start, DateT
 /// An empty list indicates a "rejected" reservation attempt 
 /// </summary>
 /// <param name="Reservations"></param>
-record ReservationVal( List<ReservationAtomVal> Reservations) : Value {
+public record ReservationVal( List<ReservationAtomVal> Reservations) : Value {
 
     public bool Failed() { return this.Reservations.Count == 0; }
 

--- a/src/RAL/Program.cs
+++ b/src/RAL/Program.cs
@@ -44,10 +44,11 @@ class Program {
                 Console.WriteLine("\n" + error + "\n");
             }
 
-            Interpreter.EvalStmt(program, new EnvV(), new EnvH());
-
+            Interpreter.ExecStmt(program, new EnvV(), new EnvH(), new EnvTem());
+            
             Console.WriteLine(ResourceRegistry.Instance().ToString());
 
+            Console.WriteLine(ReservationRegistry.Instance().ToString());
 
         } else {
             Console.WriteLine($"Parsing failed with {parser.errors.count} error(s).");

--- a/src/RAL/TypeChecker/EnvH.cs
+++ b/src/RAL/TypeChecker/EnvH.cs
@@ -35,12 +35,6 @@ public class EnvH {
         return parentCatRelations.TryGetValue(childCat, out parent);
     }
 
-    //Returns a 'list' of all immediate children categories
-    public IEnumerable<ResourceT> GetChildren(ResourceT category) =>
-    parentCatRelations
-        .Where(kvp => kvp.Value == category)
-        .Select(kvp => kvp.Key);
-
      public IEnumerable<ResourceT>? GetAllRelated(ResourceT category) {
         //Set of all related nodes, ancesters and decendants
         var result = new HashSet<ResourceT>();
@@ -58,26 +52,38 @@ public class EnvH {
         }
         
         // Downwards, descendants
-        foreach (ResourceT node in GetSubtree(category)) {
+        foreach (ResourceT node in GetSubTree(category)) {
             result.Add(node);
         }
 
         return result;
     }
 
-    // Used by: LookupCategoryPropertyType (reserve where-clause only)
-    public IEnumerable<ResourceT> GetSubtree(ResourceT category) {
-        var result = new HashSet<ResourceT>();
-        var stack = new Stack<ResourceT>();
-        stack.Push(category);
+    /// <summary> flat enumarable of subCategories (including itself), organised by descendant level </summary>
+    /// Used by: LookupCategoryPropertyType (reserve where-clause only)
+    public IEnumerable<ResourceT> GetSubTree(ResourceT category) {
         
-        while (stack.Count > 0) {
-            var node = stack.Pop();
-            if (result.Add(node))
-                foreach (var child in GetChildren(node))
-                    stack.Push(child);
+        HashSet<ResourceT> subCategories  = [];
+        
+        //breadth first, i.e. organised by nearest descendants
+        var queue = new Queue<ResourceT>();
+        queue.Enqueue(category);
+
+        while (queue.Count > 0) {
+            ResourceT current = queue.Dequeue();
+            subCategories.Add(current);
+
+            foreach (ResourceT child in GetChildren(current))
+                queue.Enqueue(child);
         }
-        return result;
+
+        return subCategories;
     }
+
+    /// <summary> Find all categories whose immediate parent is 'current' </summary>
+    private IEnumerable<ResourceT> GetChildren(ResourceT category) =>  
+        parentCatRelations
+            .Where(relation => relation.Value == category)
+            .Select(relation => relation.Key);
 
 }

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -324,64 +324,86 @@ class TypeChecker {
         foreach(ResourceSpec resourceSpec in resourceSpecs) { // loop over the [[a rc ident] and [a rc ident] and [a rc ident] and ...]
             
             // "a rc" or "a rc id"
-            if (resourceSpec.Quantity != null && resourceSpec.CategoryId != null) {
-    
-                TypeT quantityType = ExpType(resourceSpec.Quantity, envV, envC, envH, envT, envR, envCPT);
+            switch(resourceSpec) {
+                case ResourceInstanceSpec rs: {
+                    TypeT? type = envV.Lookup(rs.ResourceId);
 
-                if(quantityType is ErrorT) return false;
-
-                if (quantityType is not NumberT) {
-                    errors.Add($"Expected type 'Number' got '{quantityType}.");
-                    isWellTyped = false;
+                    if(type == null) {
+                        errors.Add($"Use of undeclared variable '{rs.ResourceId}'.");
+                        isWellTyped = false;
+                        continue;
+                    }
+                    if (type is not ResourceT) {
+                        errors.Add($"Expected type 'Resource' got '{type}'.");
+                        isWellTyped = false;
+                    }
+                    break;
                 }
 
-                if (!envC.CategoryIsDeclared(resourceSpec.CategoryId)) {
-                    errors.Add($"Use of undeclared category '{resourceSpec.CategoryId}'.");
-                    isWellTyped = false;
+                case CategorySpecWithBinding cb: {
+                    isWellTyped = HandleCategorySpec(cb, envV, envC, envH, envT, envR, envCPT);
+
+                    bool bound = envV.Bind(cb.LocalBindingId, new ResourceT(cb.CategoryId));
+                    if(!bound) errors.Add($"Variable '{cb.LocalBindingId}' already declared in current scope.");
+                    
+                    break; 
                 }
 
-                if (resourceSpec.Identifier != null) {
-                    bool bound = envV.Bind(resourceSpec.Identifier, new ResourceT(resourceSpec.CategoryId));
-                    if(!bound) errors.Add($"Variable '{resourceSpec.Identifier}' already declared in current scope.");
+                case CategorySpec cs: {
+                    isWellTyped = HandleCategorySpec(cs, envV, envC, envH, envT, envR, envCPT);
+                    break;
                 }
+
+                default: throw new Exception("Invalid resource specification.");
             }
-
-            // "id"
-            else if (resourceSpec.Identifier != null && resourceSpec.Quantity == null) {
-                TypeT? type = envV.Lookup(resourceSpec.Identifier);
-
-                if(type == null) {
-                    errors.Add($"Use of undeclared variable '{resourceSpec.Identifier}'.");
-                    isWellTyped = false;
-                    continue;
-                }
-                if (type is not ResourceT) {
-                    errors.Add($"Expected type 'Resource' got '{type}'.");
-                    isWellTyped = false;
-                }
-            }
-
-            else {
-                // invalid combination
-                throw new Exception("Invalid resource specification."); // should never happen
-            }
+            
         }
 
         return isWellTyped;
     }
+
+
+    private bool HandleCategorySpec(CategorySpec cs, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
+
+        bool isWellTyped = true;
+
+        TypeT quantityType = ExpType(cs.Quantity, envV, envC, envH, envT, envR, envCPT);
+
+        if(quantityType is ErrorT) return false;
+
+        if (quantityType is not NumberT) {
+            errors.Add($"Expected type 'Number' got '{quantityType}.");
+            isWellTyped = false;
+        }
+
+        if (!envC.CategoryIsDeclared(cs.CategoryId)) {
+            errors.Add($"Use of undeclared category '{cs.CategoryId}'.");
+            isWellTyped = false;
+        }
+
+        return isWellTyped;
+    }
+
     private bool TimeSpecIsWellTyped(TimeSpec timeSpec, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
-        TypeT fromType = ExpType(timeSpec.Start, envV, envC, envH, envT, envR, envCPT );
+        TypeT fromType = ExpType(timeSpec.Start, envV, envC, envH, envT, envR, envCPT);
         TypeT toType = ExpType(timeSpec.EndMarker, envV, envC, envH, envT, envR, envCPT);
 
         if (fromType is ErrorT || toType is ErrorT)
             return false;
-        
-        return (fromType, toType) switch {
-            (DateTimeT, DateTimeT) => true, // dt to dt
-            (DateTimeT, DurationT) => true, // dt for dur
-            _  => Error($"Types {fromType.ToString()} and {toType.ToString()} incompatible with interval expression.", false)
-        };
+
+        switch(timeSpec) {
+            case TimeSpecTo: 
+                if(fromType is DateTimeT && toType is DateTimeT) return true;
+                return Error($"Expected 'from 'DateTime' to 'DateTime'' got 'from '{fromType.ToString()}' to '{toType.ToString()}''.", false);
+
+            case TimeSpecFor:
+                if(fromType is DateTimeT && toType is DurationT) return true;
+                return Error($"Expected 'from 'DateTime' for 'Duration'' got 'from '{fromType.ToString()}' for '{toType.ToString()}''.", false);
+
+            default: throw new Exception("Invalid time specification.");
+        }
     }
+    
 
     private bool ConditionIsWellTyped(Exp? condition, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         if(condition == null) return true; // cannot be illtyped if not present
@@ -399,17 +421,24 @@ class TypeChecker {
     private bool RecurrenceIsWellTyped(RecurrenceSpec? recurrence, EnvV envV, EnvC envC, EnvH envH, EnvT envT, EnvR envR, EnvCPT envCPT) {
         if(recurrence == null) return true; // cannot be illtyped if not present
 
-        TypeT everyType = ExpType(recurrence.EveryDuration, envV, envC, envH, envT, envR, envCPT);
-        TypeT endType = ExpType(recurrence.EndMarker, envV, envC, envH, envT, envR, envCPT);
+        TypeT everyType = ExpType(recurrence.Time.Every, envV, envC, envH, envT, envR, envCPT);
+        TypeT endType = ExpType(recurrence.Time.EndMarker, envV, envC, envH, envT, envR, envCPT);
 
         if (everyType is ErrorT || endType is ErrorT)
             return false;
+        
 
-        return (everyType, endType) switch {
-            (DurationT, DateTimeT) => true, // needs way to distinguish between for/until
-            (DurationT, DurationT) => true,
-            _  => Error($"Types '{everyType.ToString()}' and '{endType.ToString()}' incompatible for recurrence.", false)       
-        };
+        switch(recurrence.Time) {
+            case RecurrenceFor: 
+                if(everyType is DurationT && endType is DurationT) return true;
+                return Error($"Expected 'every 'Duration' for 'Duration'' got 'every '{everyType.ToString()}' for '{endType.ToString()}''.", false);
+
+            case RecurrenceUntil: 
+                if(everyType is DurationT && endType is DateTimeT) return true;
+                return Error($"Expected 'every 'Duration' until 'DateTime'' got 'every '{everyType.ToString()}' until '{endType.ToString()}''.", false);
+
+             default: throw new Exception("Invalid recurrence specification.");
+        }
     }    
     
     /*________________________END: Query___________________________________________*/

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -493,7 +493,7 @@ class TypeChecker {
     private TypeT LookupCategoryPropertyType(ResourceT category, string propertyId, EnvH envH, EnvCPT envCPT) {
         
         //Check all categories in subtree
-       foreach (ResourceT related in envH.GetSubtree(category)) {
+       foreach (ResourceT related in envH.GetSubTree(category)) {
             
             if (envCPT.HasProperty(related.Category, propertyId)) 
                 return envCPT.Lookup(related.Category, propertyId);

--- a/src/RAL/TypeChecker/TypeChecker.cs
+++ b/src/RAL/TypeChecker/TypeChecker.cs
@@ -1,6 +1,4 @@
-using System.ComponentModel;
 using RAL.AST;
-using RAL.Interpreter;
 namespace RAL.TC;
 
 class TypeChecker {


### PR DESCRIPTION
## Hvad gør denne PR?
Implements: 
- Reserve & Availability of a single query
- Logic for evaluating binary reserve expressions, and reusing logic for recurrence.
  - Reccurring strict -> And chain
  - Recurring flexible -> Seq chain

- Cancel, reschedule reservations
- template declarations & calls

## Hvorfor?
Reserve atoms must be simulated for reccurrence with calculated times stripping reccurrence, since each occurrence does not provide explicit nodes with QueryData.

- A runtime mirroring class ResolvedQuery has been implemented, using native c# dateTimes and stripping recurrence (representing one atomic reserve expression). 

- Alternative considered: no resolvedQuery class, copy/repackage original QueryData object of node, with recurrence set to null and overwritten time Spec. 
  - Pro, everything is treated the same as 'ast' nodes. 
  - Con: less effeciency, more indirection, responsibility blurred as interpreter would effectively start creating nodes, which would then have to be evaluated - rather than directly evaluating on runtime values.